### PR TITLE
Try python:3.6-buster builds that don't push containers, ala ENN

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -5,16 +5,7 @@ steps:
         # Images come from hierarchy at: https://github.com/docker-library/python
         image: python:3.6-buster
         commands:
-            - rm -rf leafbuild '${{CF_REPO_NAME}}' venv
-
-    clone_leafbuild_repo:
-        type: git-clone
-        title: Clone leafbuild repo
-        description: Clone the leafbuild repository to pick up Dockerfile \
-                     and any other build stuff common between repos.
-        repo: leaf-ai/leafbuild
-        git: github
-        revision: master
+            - rm -rf '${{CF_REPO_NAME}}' venv
 
     clone_leaf-common:
         type: git-clone
@@ -102,4 +93,4 @@ steps:
         title: Clean up CodeFresh volume
         image: python:3.6-buster
         commands:
-            - rm -rf leafbuild '${{CF_REPO_NAME}}' venv
+            - rm -rf '${{CF_REPO_NAME}}' venv


### PR DESCRIPTION
Make leaf-common builds more like ENN Builds that do not need to push a container:
* Use python:3.6-buster as the container basis for each step
* Add clean up steps before and after the build
* Take the requirements import that was in the Dockerfile and put that explicitly in the "install dependencies" step. These requirements go into a virtual env used by subsequent steps.
* split flake8 and pylint into 2 different steps. This way when a step fails, you know which one died in the slack channel.

The last thing I had to do was go into the build configuration in CodeFresh and tweak it so that it would look at the codefresh.yaml file for a particular branch. This is much better than copy/pasting the config into CodeFresh UI itself as it allows for build steps to be checked in and incremental change to be under source control