### PR TITLE
Update copyrights with template to include 2021

### DIFF
--- a/build_scripts/source_available_copyright.txt
+++ b/build_scripts/source_available_copyright.txt
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/candidates/constants.py
+++ b/leaf_common/candidates/constants.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/candidates/representation_types.py
+++ b/leaf_common/candidates/representation_types.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/config/config_filter.py
+++ b/leaf_common/config/config_filter.py
@@ -1,11 +1,12 @@
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/config/config_filter_chain.py
+++ b/leaf_common/config/config_filter_chain.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/config/config_handler.py
+++ b/leaf_common/config/config_handler.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/config/dictionary_overlay.py
+++ b/leaf_common/config/dictionary_overlay.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/config/environment_defaults.py
+++ b/leaf_common/config/environment_defaults.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/evaluation/component_evaluator.py
+++ b/leaf_common/evaluation/component_evaluator.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/log_utils/message_type.py
+++ b/leaf_common/log_utils/message_type.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/log_utils/structured_message.py
+++ b/leaf_common/log_utils/structured_message.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/persistence/easy/abstract_easy_persistence.py
+++ b/leaf_common/persistence/easy/abstract_easy_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/easy/easy_hocon_persistence.py
+++ b/leaf_common/persistence/easy/easy_hocon_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/easy/easy_json_persistence.py
+++ b/leaf_common/persistence/easy/easy_json_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/easy/easy_txt_persistence.py
+++ b/leaf_common/persistence/easy/easy_txt_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/easy/easy_yaml_persistence.py
+++ b/leaf_common/persistence/easy/easy_yaml_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/abstract_persistence.py
+++ b/leaf_common/persistence/factory/abstract_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/hocon_persistence.py
+++ b/leaf_common/persistence/factory/hocon_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/json_gzip_persistence.py
+++ b/leaf_common/persistence/factory/json_gzip_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/json_persistence.py
+++ b/leaf_common/persistence/factory/json_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/null_persistence.py
+++ b/leaf_common/persistence/factory/null_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/override_file_extension_provider.py
+++ b/leaf_common/persistence/factory/override_file_extension_provider.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/persistence_factory.py
+++ b/leaf_common/persistence/factory/persistence_factory.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/raw_bytes_persistence.py
+++ b/leaf_common/persistence/factory/raw_bytes_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/reference_helper.py
+++ b/leaf_common/persistence/factory/reference_helper.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/simple_file_persistence.py
+++ b/leaf_common/persistence/factory/simple_file_persistence.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/persistence/factory/text_persistence.py
+++ b/leaf_common/persistence/factory/text_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/factory/yaml_persistence.py
+++ b/leaf_common/persistence/factory/yaml_persistence.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/interface/persistence.py
+++ b/leaf_common/persistence/interface/persistence.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/persistence/interface/persistence_mechanism.py
+++ b/leaf_common/persistence/interface/persistence_mechanism.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/interface/persistor.py
+++ b/leaf_common/persistence/interface/persistor.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/persistence/interface/restorer.py
+++ b/leaf_common/persistence/interface/restorer.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/persistence/mechanism/abstract_persistence_mechanism.py
+++ b/leaf_common/persistence/mechanism/abstract_persistence_mechanism.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/mechanism/local_file_persistence_mechanism.py
+++ b/leaf_common/persistence/mechanism/local_file_persistence_mechanism.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/mechanism/persistence_mechanism_factory.py
+++ b/leaf_common/persistence/mechanism/persistence_mechanism_factory.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/mechanism/persistence_mechanisms.py
+++ b/leaf_common/persistence/mechanism/persistence_mechanisms.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/persistence/mechanism/s3_file_persistence_mechanism.py
+++ b/leaf_common/persistence/mechanism/s3_file_persistence_mechanism.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/representation/registry/representation_file_extension_provider_registry.py
+++ b/leaf_common/representation/registry/representation_file_extension_provider_registry.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/registry/representation_persistence_registry.py
+++ b/leaf_common/representation/registry/representation_persistence_registry.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/registry/representation_serialization_format_registry.py
+++ b/leaf_common/representation/registry/representation_serialization_format_registry.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/registry/self_identifying_restorer.py
+++ b/leaf_common/representation/registry/self_identifying_restorer.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/data/condition.py
+++ b/leaf_common/representation/rule_based/data/condition.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/data/rule.py
+++ b/leaf_common/representation/rule_based/data/rule.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/data/rule_set.py
+++ b/leaf_common/representation/rule_based/data/rule_set.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/data/rules_constants.py
+++ b/leaf_common/representation/rule_based/data/rules_constants.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/evaluation/condition_evaluator.py
+++ b/leaf_common/representation/rule_based/evaluation/condition_evaluator.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/evaluation/rule_evaluator.py
+++ b/leaf_common/representation/rule_based/evaluation/rule_evaluator.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/evaluation/rule_set_evaluator.py
+++ b/leaf_common/representation/rule_based/evaluation/rule_set_evaluator.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/persistence/rule_set_file_persistence.py
+++ b/leaf_common/representation/rule_based/persistence/rule_set_file_persistence.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/serialization/condition_dictionary_converter.py
+++ b/leaf_common/representation/rule_based/serialization/condition_dictionary_converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/serialization/rule_dictionary_converter.py
+++ b/leaf_common/representation/rule_based/serialization/rule_dictionary_converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/serialization/rule_set_dictionary_converter.py
+++ b/leaf_common/representation/rule_based/serialization/rule_set_dictionary_converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/representation/rule_based/serialization/rule_set_serialization_format.py
+++ b/leaf_common/representation/rule_based/serialization/rule_set_serialization_format.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/format/buffered_gzip_serialization_format.py
+++ b/leaf_common/serialization/format/buffered_gzip_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/chained_serialization_format.py
+++ b/leaf_common/serialization/format/chained_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/conversion_policy.py
+++ b/leaf_common/serialization/format/conversion_policy.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/gzip_serialization_format.py
+++ b/leaf_common/serialization/format/gzip_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/hocon_serialization_format.py
+++ b/leaf_common/serialization/format/hocon_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/json_serialization_format.py
+++ b/leaf_common/serialization/format/json_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/raw_bytes_serialization_format.py
+++ b/leaf_common/serialization/format/raw_bytes_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/serialization_formats.py
+++ b/leaf_common/serialization/format/serialization_formats.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/text_serialization_format.py
+++ b/leaf_common/serialization/format/text_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/format/yaml_serialization_format.py
+++ b/leaf_common/serialization/format/yaml_serialization_format.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/interface/deserializer.py
+++ b/leaf_common/serialization/interface/deserializer.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/interface/dictionary_converter.py
+++ b/leaf_common/serialization/interface/dictionary_converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/interface/file_extension_provider.py
+++ b/leaf_common/serialization/interface/file_extension_provider.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/interface/reference_pruner.py
+++ b/leaf_common/serialization/interface/reference_pruner.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/interface/self_identifying_representation_error.py
+++ b/leaf_common/serialization/interface/self_identifying_representation_error.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/interface/serialization_format.py
+++ b/leaf_common/serialization/interface/serialization_format.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/interface/serializer.py
+++ b/leaf_common/serialization/interface/serializer.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/serialization/prep/empty_dictionary_converter.py
+++ b/leaf_common/serialization/prep/empty_dictionary_converter.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/prep/pass_through_dictionary_converter.py
+++ b/leaf_common/serialization/prep/pass_through_dictionary_converter.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/serialization/prep/pass_through_reference_pruner.py
+++ b/leaf_common/serialization/prep/pass_through_reference_pruner.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/leaf_common/session/extension_packaging.py
+++ b/leaf_common/session/extension_packaging.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/session/population_response_dictionary_converter.py
+++ b/leaf_common/session/population_response_dictionary_converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/session/population_session.py
+++ b/leaf_common/session/population_session.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/session/population_session_factory.py
+++ b/leaf_common/session/population_session_factory.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/leaf_common/session/response_candidate_dictionary_converter.py
+++ b/leaf_common/session/response_candidate_dictionary_converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-LIBRARY_VERSION = "1.1.29"
+LIBRARY_VERSION = "1.1.30"
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 6)

--- a/tests/candidates/test_representation_types.py
+++ b/tests/candidates/test_representation_types.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/tests/config/dictionary_overlay_test.py
+++ b/tests/config/dictionary_overlay_test.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #
 # You can be released from the terms, and requirements of the Academic Public
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
-# ENN-release SDK Software in commercial settings.
+# leaf-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
 """

--- a/tests/representation/rule_based/test_condition.py
+++ b/tests/representation/rule_based/test_condition.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/tests/representation/rule_based/test_rule.py
+++ b/tests/representation/rule_based/test_rule.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/tests/representation/rule_based/test_rule_set.py
+++ b/tests/representation/rule_based/test_rule_set.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #

--- a/tests/session/test_extension_packaging.py
+++ b/tests/session/test_extension_packaging.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Cognizant Digital Business, Evolutionary AI.
+# Copyright (C) 2019-2021 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
 #


### PR DESCRIPTION
Update leaf-common copyright notice to include the year 2021.
Updates done by script in leafbuild/scripts/copyrights/update_copyrights.sh which uses config and template files in build_scripts folder of this repo.

Other than that, this PR is really boring, as it should be.