### PR TITLE
Remove deprecated methods. Add type hints

### DIFF
--- a/leaf_common/representation/rule_based/data/condition.py
+++ b/leaf_common/representation/rule_based/data/condition.py
@@ -105,7 +105,7 @@ class Condition:  # pylint: disable=too-many-instance-attributes
         the_string = f'{first_condition} {self.operator} {second_condition}'
         return the_string
 
-    def categorical_to_string(self, states: Dict[str, str]) ->:
+    def categorical_to_string(self, states: Dict[str, str]) -> str:
         """
         FOR EXAMPLE:(for categorical)
         'race_is_category_Hispanic' becomes 'race is Hispanic'


### PR DESCRIPTION
Some post-publishing clean-up.  These are not so urgent that they need to be published immediately.
They can wait for next version.