### PR TITLE
Create wheel file automatically: leaf-common

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -121,7 +121,7 @@ steps:
         type: aws-s3
         arguments:
             REGION: us-west-2
-            BUCKET: leaf-unileaf-wheels
+            BUCKET: ${{UNILEAF_WHEEL_BUCKET}}
             S3_INTEGRATION: amazon
             S3_PREFIX: ${{PACKAGE_NAME}}/
             SOURCE: ${{CF_VOLUME_PATH}}/${{CF_BUILD_ID}}


### PR DESCRIPTION
Similar to esp-sdk and unileaf-util. Create wheel file at each build, push to s3 only at a github Release.