### PR TITLE
Fix for UN-2476

### DIFF
--- a/leaf_common/representation/rule_based/evaluation/rule_set_binding_evaluator.py
+++ b/leaf_common/representation/rule_based/evaluation/rule_set_binding_evaluator.py
@@ -61,7 +61,6 @@ class RuleSetBindingEvaluator(ComponentEvaluator):
                 data_dictionary[key] = data[int(key)][data_index]
             actions_dict = evaluator.choose_action(model.rules, data_dictionary)
             actions = []
-            actions_dict = dict(sorted(actions_dict.items(), key=lambda x: int(x[0])))
             for action in actions_dict.values():
                 if action[RulesConstants.ACTION_COUNT_KEY] > 0:
                     actions.append(action[RulesConstants.ACTION_COEFFICIENT_KEY] /

--- a/leaf_common/representation/rule_based/evaluation/rule_set_evaluator.py
+++ b/leaf_common/representation/rule_based/evaluation/rule_set_evaluator.py
@@ -196,6 +196,11 @@ class RuleSetEvaluator(ComponentEvaluator):
         action_to_perform = self.parse_rules(rule_set)
         self._set_action_in_state(action_to_perform,
                                   self._observation_history[len(self._observation_history) - 1])
+        # Make sure the dict keys are sorted based on their numeric (and not string) values
+        # E.g., we don't want a case where the keys are in this order: '1','10','2'
+        # They should be in this order: '1', '2', '10', as, unfortunately, some upstream
+        # logic relies on the numeric ordering
+        action_to_perform = dict(sorted(action_to_perform.items(), key=lambda x: int(x[0])))
         return action_to_perform
 
     def reset(self) -> None:


### PR DESCRIPTION
RuleSetBindingEvaluator's evaluate() method returns a list of (normalized) coefficients for model actions. Below you can see a sample model actions dictionary:

{'0': 'ClaimAdjustment_is_category_Decrease', '1': 'ClaimAdjustment_is_category_Increase', '10': 'RequestAdditionalDocumentation_is_category_Yes', '2': 'ClaimAdjustment_is_category_No Change', '3': 'ImmediateApproval_is_category_No', '4': 'ImmediateApproval_is_category_Yes', '5': 'InvestigationRequired_is_category_No', '6': 'InvestigationRequired_is_category_Yes', '7': 'EngageExternalInvestigator_is_category_No', '8': 'EngageExternalInvestigator_is_category_Yes', '9': 'RequestAdditionalDocumentation_is_category_No'}

The evaluate() method iterates over model.actions values and inserts a (normalized) coefficient into a list. It is assuming that action's key in model actions dictionary, matches the coefficients index in the list. This is only true if we have less than 10 actions! In the model.actions dictionary above, we have 11 actions (0 to 10), and because the keys are string (and not integer), the order is such that key '10' shows up right after key '1', causing all actions (2 to 9) to be shifted up by one. 

I found this issue after hours of debugging and with help from @hshahrzad. @hshahrzad came up with a nice one line fix to sort the models.actions such that action '10' is last.     

** User impact **
Users would not see the rule evaluation bug when the total number of actions is 10 or more