### PR TITLE
Pass verbose on grpc calls to stop Filtering Sensitive Logs scan warning when needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-LIBRARY_VERSION = "1.2.11"
+LIBRARY_VERSION = "1.2.12"
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 10)


### PR DESCRIPTION
A lot of security scans complain about Filtering Sensitive Logs at the endpoints in AbstractServiceSession where logging happens.  To help with this, we now allow passing a verbose flag (on by default) so that methods that care about this can quiet the logs to this end.