### PR TITLE
UN-2494 Use generators in AbstractServiceSession to support gRPC streaming responses

### DIFF
--- a/leaf_common/session/abstract_service_session.py
+++ b/leaf_common/session/abstract_service_session.py
@@ -144,7 +144,7 @@ class AbstractServiceSession:
 
         self.umbrella_timeout = umbrella_timeout
 
-    # pylint: disable=too-many-positional-arguments
+    # pylint: disable=too-many-positional-arguments,too-many-locals
     def call_grpc_method(self, method_name: str,
                          stub_method_callable: Any,
                          request: Any,


### PR DESCRIPTION
Allow support for streaming responses from gRPC methods in AbstractServiceSession.

Here we embrace the notion of a Python Generator which collates "yield"-ed values into something
that is iterable but also potentially blocking between iterations.

gRPC methods that stream their responses return a Generator for those responses so they can be iterator over in a for-loop.

There is a separate very similar thing called an AsyncGenerator for asynchronous code, but with this PR I am not going into async land just yet.