### PR TITLE
UN-2813 Fix AsyncioExecutor shutdown logic.

### DIFF
--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -248,7 +248,7 @@ class AsyncioExecutor(Executor):
         :param cancel_futures: Ignored? Default is False.
         """
         self._shutdown = True
-        self._loop.stop()
+        self._loop.call_soon_threadsafe(self._loop.stop)
         if wait:
             self._thread.join()
         self._thread = None


### PR DESCRIPTION
That seems to be the right way of clean shutdown for event loop + thread in AsyncioExecutor instance.
The old way leads to shutdown() call to just hang there.
