### PR TITLE
Tweaks to pyproject.toml in preparation for pypi publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-For code used across the various projects in the LEAF team.
+Utility code used across various software projects in Cognizant AI Labs (CAIL, nee LEAF).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = {file = ["requirements.txt"]}
 # Note that the requirements.txt dependencies do not include private dependencies
 # on purpose.  We acknowledge them with the entry below, but that doesn't really
 # do anything for packaging.
-optional-dependencies = {dev = {file = ["requirements-private.txt"]}}
+[tool.setuptools.dynamic.optional-dependencies]
+dev = { file = ["requirements-private.txt"] }
 
 [tool.setuptools.packages.find]
 # Standard setup has source existing under /src directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ fallback_version = "0.0.1"
 [project.urls]
 Homepage = "https://github.com/leaf-ai/leaf-common"
 Repository = "https://github.com/leaf-ai/leaf-common"
+Documentation = "https://github.com/leaf-ai/leaf-common#readme"
+# If we move issue tracking to github
+# Issues = "https://github.com/leaf-ai/leaf-common/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,12 @@ authors = [
 ]
 description = "LEAF team common code library"
 keywords = ["utility", "interfaces"]
-readme = "README.md"
-license = {file = "LICENSE.txt"}
-requires-python = ">=3.10" # <-- Should this be bumped up?
+readme = "README.md",
+# This license name comes from doc recommendation here
+# https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
+license = "LicenseRef-CognizantAcademicSource"
+license-files = ["LICENSE.txt"]
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -26,9 +29,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
 
     "Intended Audience :: Developers",
-
-    # We still need to classify our academic license
-    # "License :: XXX :: XXX" <--Need to figure out what goes in here
 ]
 # "dynamic" says we are going to get these project properties by dynamic means.
 # More on each below
@@ -37,12 +37,6 @@ dynamic = ["version", "dependencies"]
 [tool.setuptools.dynamic]
 # Specify the dependencies for the library from what is given in requirements.txt
 dependencies = {file = ["requirements.txt"]}
-
-# Note that the requirements.txt dependencies do not include private dependencies
-# on purpose.  We acknowledge them with the entry below, but that doesn't really
-# do anything for packaging.
-[tool.setuptools.dynamic.optional-dependencies]
-dev = { file = ["requirements-private.txt"] }
 
 [tool.setuptools.packages.find]
 # Standard setup has source existing under /src directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "LEAF team common code library"
 keywords = ["utility", "interfaces"]
 readme = "README.md"
 license = {file = "LICENSE.txt"}
-requires-python = ">=3.10"
+requires-python = ">=3.10" # <-- Should this be bumped up?
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -28,7 +28,7 @@ classifiers = [
     "Intended Audience :: Developers",
 
     # We still need to classify our academic license
-    # "License :: XXX :: XXX"
+    # "License :: XXX :: XXX" <--Need to figure out what goes in here
 ]
 # "dynamic" says we are going to get these project properties by dynamic means.
 # More on each below

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "LEAF team common code library"
 keywords = ["utility", "interfaces"]
-readme = "README.md",
+readme = "README.md"
 # This license name comes from doc recommendation here
 # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
 license = "LicenseRef-CognizantAcademicSource"


### PR DESCRIPTION
This is a little PR to implement some tweaks as recommended by gpt as we get ready for pypi publishing. There is an inline question about what our license type is.