### PR TITLE
Provide github actions to test and publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]  # Trigger only when a GitHub Release is published
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    environment: pypi  # Match this to your configured GitHub Environment
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build tools
+        run: |
+          pip install --upgrade pip
+          pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,13 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [published]  # Trigger only when a GitHub Release is published
+    types: [published]  # Trigger only when a GitHub Release is published.
 
 jobs:
   publish:
     name: Build and Publish
     runs-on: ubuntu-latest
-    environment: pypi  # Match this to your configured GitHub Environment
+    environment: pypi  # Match this to your configured GitHub Environment.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,15 @@ jobs:
           pip install -r requirements-build.txt
           pip install -r requirements.txt
 
-      - name: Run tests
-        run: |
-          pip freeze
-          build_scripts/run_pylint.sh
-          flake8
-          pytest --verbose -m "not integration" --timer-top-n 10
+      - name: Show installed packages
+        run: pip freeze
 
+      - name: Run pylint
+        run: build_scripts/run_pylint.sh
+
+      - name: Run flake8
+        run: flake8
+
+      - name: Run pytest (excluding integration tests)
+        run: pytest --verbose -m "not integration" --timer-top-n 10
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requriments-build.txt
+          pip install -r requirements-build.txt
           pip install -r requirements.txt
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,12 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - "**"
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.12-slim
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          pip install -r requriments-build.txt
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          pip freeze
+          build_scripts/run_pylint.sh
+          flake8
+          pytest --verbose -m "not integration" --timer-top-n 10
+
+


### PR DESCRIPTION
Two yaml files in the .github/workflows directory to

- Run tests at commits to leaf-common
- Publish to pypi when we do a Github Release from the console

There is a lot of flexibility in the yaml as to exactly when we run things, but this should mimic our current workflow.

We won't own the namespace "leaf-common" until we publish our first package there.