### PR TITLE
Cleanup after initial pypi release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,25 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Notify Slack on success
+        if: success()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "✅ *Publish Action Passed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "❌ *Publish Action Failed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Check README renders correctly on PyPI
         run: |
-          pip install readme_renderer
+          pip install readme_renderer readme_renderer[md]
           python -m readme_renderer README.md
 
       - name: Notify Slack on success

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,11 @@ jobs:
 
       - name: Run pytest (excluding integration tests)
         run: pytest --verbose -m "not integration" --timer-top-n 10
+      
+      - name: Lint Markdown
+        run: |
+          npm install -g markdownlint-cli2
+          markdownlint-cli2 '**/*.md'
 
       - name: Notify Slack on success
         if: success()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Run pytest (excluding integration tests)
         run: pytest --verbose -m "not integration" --timer-top-n 10
       
-      - name: Lint Markdown
+      - name: Check README renders correctly on PyPI
         run: |
-          npm install -g markdownlint-cli2
-          markdownlint-cli2 '**/*.md'
+          pip install readme_renderer
+          python -m readme_renderer README.md
 
       - name: Notify Slack on success
         if: success()


### PR DESCRIPTION
This PR and other similar PRs across other repos deals takes care of some cleanup items after our initial publication to pypi. Items addressed here:

- Post a success/failure message to our slack channel when the Publish action runs
- Run markdown linter at each Test action, because malformed markdown will break the publish process
- exclude build_scripts directory from MANIFEST where that file exists