### PR TITLE
Only log "could not find" messages when verbose mode is enabled

### DIFF
--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -81,8 +81,9 @@ class Resolver():
             message: str = f"Could not find code for {use_module_name}"
             messages.append(message)
             for message in messages:
-                # Always print a message when we couldn't find something
-                logger.info(message)
+                # Only print a message when we couldn't find something if verbose.
+                if verbose:
+                    logger.warning(message)
             if raise_if_not_found:
                 raise ValueError(str(messages))
         elif verbose:


### PR DESCRIPTION
## Summary
- Changed the "Could not find code for..." log message in `Resolver` to only
  emit when `verbose=True`, consistent with other verbose-gated logging in the same method
- Upgraded the log level from `info` to `warning` to better signal the significance
  of a missing module when it does appear

## Why
Previously, this message was always logged regardless of the `verbose` flag, which was
inconsistent with how the rest of the resolver handles diagnostic output. This caused
noise in non-verbose contexts where callers don't expect log output unless they've
opted in.
