### PR TITLE
NS-966 Extend AsyncExecutor run-time metrics.

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -36,3 +36,9 @@ jobs:
         version: 'ver.0.6.0'
         include_detector_types: 'PIP'
         bdh_accuracy_required: 'NONE' 
+ 
+  SonarQube_scan:
+    uses: CognizantCodeHub/IPReady_workflows/.github/workflows/sonarqube_generic_scan.yml@Rel-1.0
+    with:
+      ProjectName: ${{ github.event.repository.name }} 
+    secrets: inherit     

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -36,9 +36,3 @@ jobs:
         version: 'ver.0.6.0'
         include_detector_types: 'PIP'
         bdh_accuracy_required: 'NONE' 
- 
-  SonarQube_scan:
-    uses: CognizantCodeHub/IPReady_workflows/.github/workflows/sonarqube_generic_scan.yml@Rel-1.0
-    with:
-      ProjectName: ${{ github.event.repository.name }} 
-    secrets: inherit     

--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -22,6 +22,7 @@ from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Tuple
 
 import asyncio
 import functools
@@ -36,6 +37,7 @@ from asyncio import Task
 from concurrent import futures
 
 from leaf_common.asyncio.task_executor import TaskExecutor
+from leaf_common.asyncio.asyncio_threadpool_executor import AsyncioThreadPoolExecutor
 
 EXECUTOR_START_TIMEOUT_SECONDS: int = 5
 
@@ -57,8 +59,10 @@ class AsyncioExecutor(TaskExecutor):
         self._thread: threading.Thread = None
         # We are going to start new thread for this Executor,
         # so we need a new event loop bound to this particular thread:
+        self._threadpool_executor: AsyncioThreadPoolExecutor = AsyncioThreadPoolExecutor()
         self._loop: AbstractEventLoop = asyncio.new_event_loop()
         self._loop.set_exception_handler(AsyncioExecutor.loop_exception_handler)
+        self._loop.set_default_executor(self._threadpool_executor)
         self._loop_ready = threading.Event()
         self._init_done = threading.Event()
         self._background_tasks: Dict[int, Dict[str, Any]] = {}
@@ -445,6 +449,16 @@ class AsyncioExecutor(TaskExecutor):
         # we use to keep its reference around. Do it safely:
         with self._background_tasks_lock:
             self._background_tasks.pop(task_id, None)
+
+    def get_threads_metrics(self) -> Tuple[int, int]:
+        """
+        For ThreadExecutorPool used by our event loop,
+        get number of created threads and number of currently running threads.
+         :return: Tuple of (number of threads in the pool, number of currently running threads)
+        """
+        if self._threadpool_executor:
+            return self._threadpool_executor.get_threads_metrics()
+        return 0, 0
 
     def shutdown(self, wait: bool = True, *, cancel_futures: bool = False):
         """

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -46,7 +46,7 @@ class AsyncioExecutorPool:
         # List of currently used AsyncioExecutor instances in the pool.
         self.pool_used = []
 
-        self.lock: threading.Lock = threading.Lock()
+        self.lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.debug("AsyncioExecutorPool created: %s reuse: %s",
                           id(self), str(self.reuse_mode))
@@ -77,24 +77,23 @@ class AsyncioExecutorPool:
         Return AsyncioExecutor instance back to the pool of available instances.
         :param executor: AsyncioExecutor to return.
         """
-        if executor not in self.pool_used:
-            raise ValueError(f"Returned executor {id(executor)} is not in the pool of used executors")
+        with self.lock:
+            if executor not in self.pool_used:
+                raise ValueError(f"Returned executor {id(executor)} is not in the pool of used executors")
+            self.pool_used.remove(executor)
 
+        # Executor clean up: cancel current tasks and shutdown if not in reuse mode.
         if self.reuse_mode:
             executor.cancel_current_tasks()
+        else:
+            self.logger.debug("Shutting down: AsyncioExecutor %s", id(executor))
+            executor.shutdown()
+
+        if self.reuse_mode:
             with self.lock:
-                self.pool_used.remove(executor)
                 self.pool_available.append(executor)
                 self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d",
                                   id(executor), len(self.pool_available))
-        else:
-            # Shutdown AsyncioExecutor outside of lock
-            # to avoid potentially longer locked periods
-            self.logger.debug("Shutting down: AsyncioExecutor %s", id(executor))
-            with self.lock:
-                self.pool_used.remove(executor)
-            # Note: shutdown is called outside of lock to avoid potentially long shutdown execution.
-            executor.shutdown()
 
     def get_threads_metrics(self) -> Dict[str, Any]:
         """

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -85,7 +85,8 @@ class AsyncioExecutorPool:
             with self.lock:
                 self.pool_used.remove(executor)
                 self.pool_available.append(executor)
-                self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d", id(executor), len(self.pool_available))
+                self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d",
+                                  id(executor), len(self.pool_available))
         else:
             # Shutdown AsyncioExecutor outside of lock
             # to avoid potentially longer locked periods
@@ -97,12 +98,12 @@ class AsyncioExecutorPool:
 
     def get_threads_metrics(self) -> Dict[str, Any]:
         """
-        Get metrics related to threads in the pool of executors, including:
-        - total_threads: Total number of threads across all executors in the pool (including both used and available executors).
-        - used_threads: Total number of threads across all currently used executors in the pool.
-        - used_running: Total number of currently running threads across all currently used executors in the pool.
-        - available_threads: Total number of threads across all currently available executors in the pool.
-        - available_running: Total number of currently running threads across all currently available executors in the pool.
+        Get metrics related to threads in the pool of executors:
+        for both collections of used and available executors,
+        get the total number of executors in this collection "executors",
+        the total number of work threads across all executors in this collection "work_threads",
+        and the total number of currently running work threads
+        across all executors in this collection "threads_running".
         """
         with self.lock:
             available_copy = copy.copy(self.pool_available)
@@ -111,23 +112,24 @@ class AsyncioExecutorPool:
         used_running: int = 0
         available_threads: int = 0
         available_running: int = 0
-        total_threads: int = 0
         for executor in used_copy:
             threads, running = executor.get_threads_metrics()
-            print(f"Used executor {id(executor)} threads: {threads} running: {running}")
             used_threads += threads
             used_running += running
         for executor in available_copy:
             threads, running = executor.get_threads_metrics()
-            print(f"Available executor {id(executor)} threads: {threads} running: {running}")
             available_threads += threads
             available_running += running
         result_dict = {
-            "used_executors": len(used_copy),
-            "used_threads": used_threads,
-            "used_running": used_running,
-            "available_executors": len(available_copy),
-            "available_threads": available_threads,
-            "available_running": available_running
+            "used": {
+                "executors": len(used_copy),
+                "work_threads": used_threads,
+                "threads_running": used_running
+            },
+            "available": {
+                "executors": len(available_copy),
+                "work_threads": available_threads,
+                "threads_running": available_running
+            }
         }
         return result_dict

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -122,11 +122,11 @@ class AsyncioExecutorPool:
             print(f"Available executor {id(executor)} threads: {threads} running: {running}")
             available_threads += threads
             available_running += running
-        total_threads = used_threads + len(used_copy) + available_threads + len(available_copy)
         result_dict = {
-            "total_threads": total_threads,
+            "used_executors": len(used_copy),
             "used_threads": used_threads,
             "used_running": used_running,
+            "available_executors": len(available_copy),
             "available_threads": available_threads,
             "available_running": available_running
         }

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -68,7 +68,8 @@ class AsyncioExecutorPool:
         result = AsyncioExecutor()
         result.start()
         self.logger.debug("Creating AsyncioExecutor %s", id(result))
-        self.pool_used.append(result)
+        with self.lock:
+            self.pool_used.append(result)
         return result
 
     def return_executor(self, executor: AsyncioExecutor):
@@ -113,10 +114,12 @@ class AsyncioExecutorPool:
         total_threads: int = 0
         for executor in used_copy:
             threads, running = executor.get_threads_metrics()
+            print(f"Used executor {id(executor)} threads: {threads} running: {running}")
             used_threads += threads
             used_running += running
         for executor in available_copy:
             threads, running = executor.get_threads_metrics()
+            print(f"Available executor {id(executor)} threads: {threads} running: {running}")
             available_threads += threads
             available_running += running
         total_threads = used_threads + len(used_copy) + available_threads + len(available_copy)

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -17,7 +17,10 @@
 """
 See class comments
 """
+from typing import Any
+from typing import Dict
 
+import copy
 import logging
 import threading
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
@@ -37,7 +40,12 @@ class AsyncioExecutorPool:
                                  and shutdown on return (backward compatible mode)
         """
         self.reuse_mode: bool = reuse_mode
-        self.pool = []
+        # List of available (not currently used) AsyncioExecutor instances in the pool.
+        self.pool_available = []
+
+        # List of currently used AsyncioExecutor instances in the pool.
+        self.pool_used = []
+
         self.lock: threading.Lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.debug("AsyncioExecutorPool created: %s reuse: %s",
@@ -50,15 +58,17 @@ class AsyncioExecutorPool:
         """
         if self.reuse_mode:
             with self.lock:
-                if len(self.pool) > 0:
-                    result = self.pool.pop(0)
+                if len(self.pool_available) > 0:
+                    result = self.pool_available.pop(0)
                     self.logger.debug("Reusing AsyncioExecutor %s", id(result))
+                    self.pool_used.append(result)
                     return result
         # Create AsyncioExecutor outside of lock
         # to avoid potentially longer locked periods
         result = AsyncioExecutor()
         result.start()
         self.logger.debug("Creating AsyncioExecutor %s", id(result))
+        self.pool_used.append(result)
         return result
 
     def return_executor(self, executor: AsyncioExecutor):
@@ -66,13 +76,55 @@ class AsyncioExecutorPool:
         Return AsyncioExecutor instance back to the pool of available instances.
         :param executor: AsyncioExecutor to return.
         """
+        if executor not in self.pool_used:
+            raise ValueError(f"Returned executor {id(executor)} is not in the pool of used executors")
+
         if self.reuse_mode:
+            executor.cancel_current_tasks()
             with self.lock:
-                executor.cancel_current_tasks()
-                self.pool.append(executor)
-                self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d", id(executor), len(self.pool))
+                self.pool_used.remove(executor)
+                self.pool_available.append(executor)
+                self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d", id(executor), len(self.pool_available))
         else:
             # Shutdown AsyncioExecutor outside of lock
             # to avoid potentially longer locked periods
             self.logger.debug("Shutting down: AsyncioExecutor %s", id(executor))
+            with self.lock:
+                self.pool_used.remove(executor)
+            # Note: shutdown is called outside of lock to avoid potentially long shutdown execution.
             executor.shutdown()
+
+    def get_threads_metrics(self) -> Dict[str, Any]:
+        """
+        Get metrics related to threads in the pool of executors, including:
+        - total_threads: Total number of threads across all executors in the pool (including both used and available executors).
+        - used_threads: Total number of threads across all currently used executors in the pool.
+        - used_running: Total number of currently running threads across all currently used executors in the pool.
+        - available_threads: Total number of threads across all currently available executors in the pool.
+        - available_running: Total number of currently running threads across all currently available executors in the pool.
+        """
+        with self.lock:
+            available_copy = copy.copy(self.pool_available)
+            used_copy = copy.copy(self.pool_used)
+        used_threads: int = 0
+        used_running: int = 0
+        available_threads: int = 0
+        available_running: int = 0
+        total_threads: int = 0
+        for executor in used_copy:
+            threads, running = executor.get_threads_metrics()
+            used_threads += threads
+            used_running += running
+        for executor in available_copy:
+            threads, running = executor.get_threads_metrics()
+            available_threads += threads
+            available_running += running
+        total_threads = used_threads + len(used_copy) + available_threads + len(available_copy)
+        result_dict = {
+            "total_threads": total_threads,
+            "used_threads": used_threads,
+            "used_running": used_running,
+            "available_threads": available_threads,
+            "available_running": available_running
+        }
+        return result_dict

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -34,10 +34,7 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
         self.running: int = 0
         self.lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.has_threads_attr: bool = hasattr(self, "_threads")
-        if not self.has_threads_attr:
-            self.logger.info("ThreadPoolExecutor does not have _threads attribute, "
-                             "number of threads in the pool will not be available")
+        self.no_threads_warning_logged: bool = False
 
     def submit(self, fn, /, *args, **kwargs):
         """
@@ -64,7 +61,11 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                which may not be available in all implementations of ThreadPoolExecutor.
         """
         num_threads: int = 0
-        if self.has_threads_attr:
+        if hasattr(self, "_threads"):
             num_threads = len(self._threads)
+        elif not self.no_threads_warning_logged:
+                self.logger.warning("ThreadPoolExecutor does not have _threads attribute, "
+                                    "number of threads in the pool will be reported as 0")
+                self.no_threads_warning_logged = True
         with self.lock:
             return num_threads, self.running

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -44,7 +44,7 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                 f"kwargs={fn.keywords!r})"
             )
 
-        return f"{fn.__module__}.{fn.__qualname__}"
+        return f"{fn.__module__}/{fn.__qualname__}"
 
     def submit(self, fn, /, *args, **kwargs):
         """

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -48,6 +48,8 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                 with self.lock:
                     self.running -= 1
 
+        name = f"{fn.__module__}.{fn.__qualname__}"
+        print(f"======================Submitting task {name} [{self.running}] to {self.__class__.__name__}")
         return super().submit(wrapped, *args, **kwargs)
 
     def get_threads_metrics(self) -> Tuple[int, int]:

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -64,8 +64,8 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
         if hasattr(self, "_threads"):
             num_threads = len(self._threads)
         elif not self.no_threads_warning_logged:
-                self.logger.warning("ThreadPoolExecutor does not have _threads attribute, "
-                                    "number of threads in the pool will be reported as 0")
-                self.no_threads_warning_logged = True
+            self.logger.warning("ThreadPoolExecutor does not have _threads attribute, "
+                                "number of threads in the pool will be reported as 0")
+            self.no_threads_warning_logged = True
         with self.lock:
             return num_threads, self.running

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -20,6 +20,7 @@ See class comment for details.
 from typing import Tuple
 from concurrent.futures import ThreadPoolExecutor
 import logging
+import functools
 import threading
 
 class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
@@ -33,6 +34,17 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
         self.running: int = 0
         self.lock: threading.Lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
+
+    def _format_callable(self, fn):
+        if isinstance(fn, functools.partial):
+            return (
+                f"partial("
+                f"{self._format_callable(fn.func)}, "
+                f"args={fn.args!r}, "
+                f"kwargs={fn.keywords!r})"
+            )
+
+        return f"{fn.__module__}.{fn.__qualname__}"
 
     def submit(self, fn, /, *args, **kwargs):
         """
@@ -48,7 +60,7 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                 with self.lock:
                     self.running -= 1
 
-        name = f"{fn.__module__}.{fn.__name__}"
+        name = self._format_callable(fn)
         print(f"======================Submitting task {name} [{self.running}] to {self.__class__.__name__}")
         return super().submit(wrapped, *args, **kwargs)
 

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -34,6 +34,10 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
         self.running: int = 0
         self.lock: threading.Lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.has_threads_attr: bool = hasattr(self, "_threads")
+        if not self.has_threads_attr:
+            self.logger.info("ThreadPoolExecutor does not have _threads attribute, "
+                             "number of threads in the pool will not be available")
 
     def submit(self, fn, /, *args, **kwargs):
         """
@@ -60,9 +64,7 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                which may not be available in all implementations of ThreadPoolExecutor.
         """
         num_threads: int = 0
-        try:
+        if self.has_threads_attr:
             num_threads = len(self._threads)
-        except AttributeError:
-            self.logger.info("FAILED to get number of threads from %s", self.__class__.__name__)
         with self.lock:
             return num_threads, self.running

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -32,7 +32,7 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
         """Constructor."""
         super().__init__(*args, **kwargs)
         self.running: int = 0
-        self.lock: threading.Lock = threading.Lock()
+        self.lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.has_threads_attr: bool = hasattr(self, "_threads")
         if not self.has_threads_attr:

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -1,0 +1,67 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from typing import Tuple
+from concurrent.futures import ThreadPoolExecutor
+import logging
+import threading
+
+class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
+    """
+    Class instrumenting a ThreadPoolExecutor with some additional run-time metrics
+    such as number of created and active threads.
+    """
+    def __init__(self, *args, **kwargs):
+        """Constructor."""
+        super().__init__(*args, **kwargs)
+        self.running: int = 0
+        self.lock: threading.Lock = threading.Lock()
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def submit(self, fn, /, *args, **kwargs):
+        """
+        Override of submit method to wrap the submitted function with additional logic
+        for counting the number of active (running) threads.
+        """
+        def wrapped(*a, **kw):
+            with self.lock:
+                self.running += 1
+            try:
+                return fn(*a, **kw)
+            finally:
+                with self.lock:
+                    self.running -= 1
+
+        return super().submit(wrapped, *args, **kwargs)
+
+    def get_threads_metrics(self) -> Tuple[int, int]:
+        """
+        Get number of threads in the pool and number of currently running threads.
+         :return: Tuple of (number of threads in the pool, number of currently running threads)
+         Note: number of threads in the pool is an approximation, as ThreadPoolExecutor does not provide
+               a direct way to get this information. The method tries to access the protected member _threads,
+               which may not be available in all implementations of ThreadPoolExecutor.
+        """
+        num_threads: int = 0
+        try:
+            num_threads = len(self._threads)
+        except AttributeError:
+            self.logger.info("FAILED to get number of threads from %s", self.__class__.__name__)
+        with self.lock:
+            return num_threads, self.running

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -48,7 +48,7 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                 with self.lock:
                     self.running -= 1
 
-        name = f"{fn.__module__}.{fn.__qualname__}"
+        name = f"{fn.__module__}.{fn.__name__}"
         print(f"======================Submitting task {name} [{self.running}] to {self.__class__.__name__}")
         return super().submit(wrapped, *args, **kwargs)
 

--- a/leaf_common/asyncio/asyncio_threadpool_executor.py
+++ b/leaf_common/asyncio/asyncio_threadpool_executor.py
@@ -20,8 +20,8 @@ See class comment for details.
 from typing import Tuple
 from concurrent.futures import ThreadPoolExecutor
 import logging
-import functools
 import threading
+
 
 class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
     """
@@ -34,17 +34,6 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
         self.running: int = 0
         self.lock: threading.Lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
-
-    def _format_callable(self, fn):
-        if isinstance(fn, functools.partial):
-            return (
-                f"partial("
-                f"{self._format_callable(fn.func)}, "
-                f"args={fn.args!r}, "
-                f"kwargs={fn.keywords!r})"
-            )
-
-        return f"{fn.__module__}/{fn.__qualname__}"
 
     def submit(self, fn, /, *args, **kwargs):
         """
@@ -60,8 +49,6 @@ class AsyncioThreadPoolExecutor(ThreadPoolExecutor):
                 with self.lock:
                     self.running -= 1
 
-        name = self._format_callable(fn)
-        print(f"======================Submitting task {name} [{self.running}] to {self.__class__.__name__}")
         return super().submit(wrapped, *args, **kwargs)
 
     def get_threads_metrics(self) -> Tuple[int, int]:

--- a/tests/asyncio/asyncio_executor_metrics_test.py
+++ b/tests/asyncio/asyncio_executor_metrics_test.py
@@ -1,0 +1,133 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for AsyncioExecutor.get_threads_metrics().
+
+The method delegates to the executor's internal AsyncioThreadPoolExecutor
+when one is present, or returns (0, 0) otherwise. The behavior of the
+threadpool itself is covered in asyncio_threadpool_executor_metrics_test;
+this module isolates AsyncioExecutor's delegation logic.
+"""
+import threading
+
+from unittest import TestCase
+
+from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
+
+
+# Module-level helper (no nested defs inside test methods).
+def block_on_event(start_event: threading.Event,
+                   release_event: threading.Event):
+    """
+    Helper task body: signals start_event when picked up by a worker thread,
+    then blocks on release_event until the test side releases it. Used to
+    pin one worker thread in the "running" state long enough for the test
+    to observe the metric via the AsyncioExecutor wrapper.
+    """
+    start_event.set()
+    release_event.wait(timeout=5.0)
+
+
+class AsyncioExecutorMetricsTest(TestCase):
+    """
+    Verifies that AsyncioExecutor.get_threads_metrics() returns the same
+    (threads, running) tuple as the underlying AsyncioThreadPoolExecutor,
+    and that the fallback path returns (0, 0) when no threadpool is set.
+    """
+
+    def setUp(self):
+        """Create and start a fresh executor."""
+        self.executor = AsyncioExecutor()
+        self.executor.start()
+
+    def tearDown(self):
+        """Always shutdown so the event-loop thread terminates cleanly."""
+        if self.executor is not None:
+            self.executor.shutdown(wait=True)
+
+    def test_metrics_on_idle_executor_report_zero(self):
+        """
+        Immediately after start(), no work has been dispatched to the
+        threadpool, so both counts are zero.
+        """
+        num_threads, num_running = self.executor.get_threads_metrics()
+        self.assertEqual(
+            0, num_threads,
+            f"Expected 0 worker threads on an idle executor, got {num_threads}.",
+        )
+        self.assertEqual(
+            0, num_running,
+            f"Expected 0 running tasks on an idle executor, got {num_running}.",
+        )
+
+    def test_metrics_reflect_work_dispatched_to_internal_threadpool(self):
+        """
+        AsyncioExecutor.get_threads_metrics() delegates to its internal
+        AsyncioThreadPoolExecutor. Submit work directly to that threadpool
+        (the same one the executor's event loop dispatches sync work to via
+        run_in_executor) and verify the delegated metrics reflect it.
+        """
+        start_event = threading.Event()
+        release_event = threading.Event()
+
+        # pylint: disable=protected-access
+        threadpool = self.executor._threadpool_executor
+        future = threadpool.submit(block_on_event, start_event, release_event)
+        self.assertTrue(
+            start_event.wait(timeout=5.0),
+            "Helper task never entered its body within 5s.",
+        )
+
+        num_threads, num_running = self.executor.get_threads_metrics()
+
+        # Release and drain before asserting, so failures do not leak
+        # a blocked worker.
+        release_event.set()
+        future.result(timeout=5.0)
+
+        self.assertGreaterEqual(
+            num_threads, 1,
+            f"Expected at least 1 worker thread mid-task, got {num_threads}.",
+        )
+        self.assertEqual(
+            1, num_running,
+            f"Expected exactly 1 running task while the helper was blocked, "
+            f"got {num_running}.",
+        )
+
+    def test_metrics_return_zero_tuple_when_threadpool_is_absent(self):
+        """
+        AsyncioExecutor.get_threads_metrics() short-circuits to (0, 0) if
+        the internal _threadpool_executor reference is falsy. Simulate
+        that branch by clearing the attribute. Avoids needing a real
+        environment where the threadpool failed to construct.
+        """
+        # pylint: disable=protected-access
+        self.executor._threadpool_executor = None
+
+        num_threads, num_running = self.executor.get_threads_metrics()
+
+        self.assertEqual(
+            0, num_threads,
+            f"Expected fallback of 0 worker threads when threadpool is absent, "
+            f"got {num_threads}.",
+        )
+        self.assertEqual(
+            0, num_running,
+            f"Expected 0 running tasks when threadpool is absent, "
+            f"got {num_running}.",
+        )

--- a/tests/asyncio/asyncio_executor_metrics_test.py
+++ b/tests/asyncio/asyncio_executor_metrics_test.py
@@ -27,19 +27,7 @@ import threading
 from unittest import TestCase
 
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
-
-
-# Module-level helper (no nested defs inside test methods).
-def block_on_event(start_event: threading.Event,
-                   release_event: threading.Event):
-    """
-    Helper task body: signals start_event when picked up by a worker thread,
-    then blocks on release_event until the test side releases it. Used to
-    pin one worker thread in the "running" state long enough for the test
-    to observe the metric via the AsyncioExecutor wrapper.
-    """
-    start_event.set()
-    release_event.wait(timeout=5.0)
+from tests.asyncio.sync_test_helpers import SyncTestHelpers
 
 
 class AsyncioExecutorMetricsTest(TestCase):
@@ -86,7 +74,7 @@ class AsyncioExecutorMetricsTest(TestCase):
 
         # pylint: disable=protected-access
         threadpool = self.executor._threadpool_executor
-        future = threadpool.submit(block_on_event, start_event, release_event)
+        future = threadpool.submit(SyncTestHelpers.block_on_event, start_event, release_event)
         self.assertTrue(
             start_event.wait(timeout=5.0),
             "Helper task never entered its body within 5s.",

--- a/tests/asyncio/asyncio_executor_pool_metrics_test.py
+++ b/tests/asyncio/asyncio_executor_pool_metrics_test.py
@@ -1,0 +1,212 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for AsyncioExecutorPool.get_threads_metrics().
+
+The pool aggregates per-executor (threads, running) tuples into a nested
+dict with "used" and "available" sections. Each section reports the
+number of executors plus the totals of their underlying thread counts.
+These tests cover the empty pool, the used/available partitioning across
+acquire/return state transitions in both reuse and non-reuse modes, and
+the aggregation arithmetic.
+"""
+from typing import Tuple
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
+
+
+def make_metrics_executor(threads: int, running: int) -> MagicMock:
+    """
+    Build a mock AsyncioExecutor whose get_threads_metrics() returns
+    the given (threads, running) tuple. Used to drive the aggregation
+    arithmetic without depending on real thread scheduling.
+    """
+    mock = MagicMock()
+    mock.get_threads_metrics.return_value: Tuple[int, int] = (threads, running)
+    return mock
+
+
+class AsyncioExecutorPoolMetricsTest(TestCase):
+    """
+    Verifies that get_threads_metrics() correctly partitions executors
+    between the "used" and "available" buckets and sums their per-executor
+    thread counts.
+    """
+
+    def tearDown(self):
+        """
+        Shutdown any real executors that may be live in the pool. Mock
+        executors are no-ops on shutdown so the call is harmless either
+        way.
+        """
+        if getattr(self, "pool", None) is None:
+            return
+        for executor in list(self.pool.pool_used) + list(self.pool.pool_available):
+            try:
+                executor.shutdown(wait=True)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
+    def test_metrics_on_empty_pool_report_all_zeros(self):
+        """
+        A freshly constructed pool has no executors in either bucket, so
+        both sections report executors=0, work_threads=0, threads_running=0.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.pool = AsyncioExecutorPool(reuse_mode=True)
+        metrics = self.pool.get_threads_metrics()
+        self.assertEqual(
+            {
+                "used": {"executors": 0, "work_threads": 0, "threads_running": 0},
+                "available": {"executors": 0, "work_threads": 0, "threads_running": 0},
+            },
+            metrics,
+            f"Expected all-zero metrics on an empty pool; got {metrics}.",
+        )
+
+    def test_metrics_count_one_used_executor_and_zero_available(self):
+        """
+        After get_executor() the pool holds the new executor in pool_used;
+        pool_available stays empty. Used.executors should be 1; available
+        section should remain all-zero.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.pool = AsyncioExecutorPool(reuse_mode=True)
+        # Replace the freshly-acquired real executor with a mock so the
+        # threads/running counts are deterministic.
+        self.pool.get_executor()
+        self.pool.pool_used[0].shutdown(wait=True)
+        self.pool.pool_used[0] = make_metrics_executor(threads=2, running=1)
+
+        metrics = self.pool.get_threads_metrics()
+
+        self.assertEqual(
+            {
+                "used": {"executors": 1, "work_threads": 2, "threads_running": 1},
+                "available": {"executors": 0, "work_threads": 0, "threads_running": 0},
+            },
+            metrics,
+            f"Expected metrics to count one used executor with its underlying "
+            f"thread counts; got {metrics}.",
+        )
+
+    def test_metrics_after_return_in_reuse_mode_move_executor_to_available(self):
+        """
+        In reuse_mode=True, return_executor() moves the executor from
+        pool_used to pool_available. The metrics should reflect the move:
+        used.executors goes 1 -> 0, available.executors goes 0 -> 1.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.pool = AsyncioExecutorPool(reuse_mode=True)
+        executor = self.pool.get_executor()
+        # Swap in a mock with deterministic metrics, mirroring what would
+        # happen if the real executor were idle after a return.
+        self.pool.pool_used[0].shutdown(wait=True)
+        mock_executor = make_metrics_executor(threads=2, running=0)
+        self.pool.pool_used[0] = mock_executor
+
+        self.pool.return_executor(mock_executor)
+
+        metrics = self.pool.get_threads_metrics()
+        self.assertEqual(
+            {
+                "used": {"executors": 0, "work_threads": 0, "threads_running": 0},
+                "available": {"executors": 1, "work_threads": 2, "threads_running": 0},
+            },
+            metrics,
+            f"Expected the returned executor to be visible in 'available' only; "
+            f"got {metrics}.",
+        )
+        # The mock should still be the same instance, since reuse_mode keeps it.
+        self.assertIs(
+            mock_executor,
+            self.pool.pool_available[0],
+            "Returned executor should be the same instance held in pool_available.",
+        )
+        # Silence unused-local warning; executor is the original real one we already shut down.
+        del executor
+
+    def test_metrics_after_return_in_non_reuse_mode_drop_executor_from_pool(self):
+        """
+        In reuse_mode=False, return_executor() shuts the executor down
+        and removes it entirely; neither bucket should hold it afterwards.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.pool = AsyncioExecutorPool(reuse_mode=False)
+        executor = self.pool.get_executor()
+        # Replace with a mock to make the assertion that shutdown() was
+        # called clean and to avoid a real shutdown race.
+        self.pool.pool_used[0].shutdown(wait=True)
+        mock_executor = make_metrics_executor(threads=2, running=1)
+        self.pool.pool_used[0] = mock_executor
+
+        self.pool.return_executor(mock_executor)
+
+        metrics = self.pool.get_threads_metrics()
+        self.assertEqual(
+            {
+                "used": {"executors": 0, "work_threads": 0, "threads_running": 0},
+                "available": {"executors": 0, "work_threads": 0, "threads_running": 0},
+            },
+            metrics,
+            f"Expected the executor to disappear from both buckets in non-reuse "
+            f"mode; got {metrics}.",
+        )
+        mock_executor.shutdown.assert_called_once()
+        del executor
+
+    def test_metrics_sum_thread_counts_across_multiple_used_executors(self):
+        """
+        With several executors in pool_used (and a separate one in
+        pool_available), work_threads and threads_running should be the
+        sums of the per-executor values, partitioned by bucket. This
+        isolates the aggregation arithmetic from any threading flakiness
+        by using mocks.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.pool = AsyncioExecutorPool(reuse_mode=True)
+        self.pool.pool_used = [
+            make_metrics_executor(threads=4, running=2),
+            make_metrics_executor(threads=3, running=3),
+            make_metrics_executor(threads=2, running=0),
+        ]
+        self.pool.pool_available = [
+            make_metrics_executor(threads=5, running=0),
+            make_metrics_executor(threads=1, running=0),
+        ]
+
+        metrics = self.pool.get_threads_metrics()
+
+        self.assertEqual(
+            {
+                "used": {
+                    "executors": 3,
+                    "work_threads": 4 + 3 + 2,           # 9
+                    "threads_running": 2 + 3 + 0,        # 5
+                },
+                "available": {
+                    "executors": 2,
+                    "work_threads": 5 + 1,               # 6
+                    "threads_running": 0 + 0,            # 0
+                },
+            },
+            metrics,
+            f"Expected per-bucket sums of underlying executor metrics; got {metrics}.",
+        )

--- a/tests/asyncio/asyncio_executor_pool_metrics_test.py
+++ b/tests/asyncio/asyncio_executor_pool_metrics_test.py
@@ -32,23 +32,23 @@ from unittest.mock import MagicMock
 from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
 
 
-def make_metrics_executor(threads: int, running: int) -> MagicMock:
-    """
-    Build a mock AsyncioExecutor whose get_threads_metrics() returns
-    the given (threads, running) tuple. Used to drive the aggregation
-    arithmetic without depending on real thread scheduling.
-    """
-    mock = MagicMock()
-    mock.get_threads_metrics.return_value: Tuple[int, int] = (threads, running)
-    return mock
-
-
 class AsyncioExecutorPoolMetricsTest(TestCase):
     """
     Verifies that get_threads_metrics() correctly partitions executors
     between the "used" and "available" buckets and sums their per-executor
     thread counts.
     """
+
+    @staticmethod
+    def make_metrics_executor(threads: int, running: int) -> MagicMock:
+        """
+        Build a mock AsyncioExecutor whose get_threads_metrics() returns
+        the given (threads, running) tuple. Used to drive the aggregation
+        arithmetic without depending on real thread scheduling.
+        """
+        mock = MagicMock()
+        mock.get_threads_metrics.return_value: Tuple[int, int] = (threads, running)
+        return mock
 
     def tearDown(self):
         """
@@ -93,7 +93,7 @@ class AsyncioExecutorPoolMetricsTest(TestCase):
         # threads/running counts are deterministic.
         self.pool.get_executor()
         self.pool.pool_used[0].shutdown(wait=True)
-        self.pool.pool_used[0] = make_metrics_executor(threads=2, running=1)
+        self.pool.pool_used[0] = self.make_metrics_executor(threads=2, running=1)
 
         metrics = self.pool.get_threads_metrics()
 
@@ -119,7 +119,7 @@ class AsyncioExecutorPoolMetricsTest(TestCase):
         # Swap in a mock with deterministic metrics, mirroring what would
         # happen if the real executor were idle after a return.
         self.pool.pool_used[0].shutdown(wait=True)
-        mock_executor = make_metrics_executor(threads=2, running=0)
+        mock_executor = self.make_metrics_executor(threads=2, running=0)
         self.pool.pool_used[0] = mock_executor
 
         self.pool.return_executor(mock_executor)
@@ -154,7 +154,7 @@ class AsyncioExecutorPoolMetricsTest(TestCase):
         # Replace with a mock to make the assertion that shutdown() was
         # called clean and to avoid a real shutdown race.
         self.pool.pool_used[0].shutdown(wait=True)
-        mock_executor = make_metrics_executor(threads=2, running=1)
+        mock_executor = self.make_metrics_executor(threads=2, running=1)
         self.pool.pool_used[0] = mock_executor
 
         self.pool.return_executor(mock_executor)
@@ -183,13 +183,13 @@ class AsyncioExecutorPoolMetricsTest(TestCase):
         # pylint: disable=attribute-defined-outside-init
         self.pool = AsyncioExecutorPool(reuse_mode=True)
         self.pool.pool_used = [
-            make_metrics_executor(threads=4, running=2),
-            make_metrics_executor(threads=3, running=3),
-            make_metrics_executor(threads=2, running=0),
+            self.make_metrics_executor(threads=4, running=2),
+            self.make_metrics_executor(threads=3, running=3),
+            self.make_metrics_executor(threads=2, running=0),
         ]
         self.pool.pool_available = [
-            make_metrics_executor(threads=5, running=0),
-            make_metrics_executor(threads=1, running=0),
+            self.make_metrics_executor(threads=5, running=0),
+            self.make_metrics_executor(threads=1, running=0),
         ]
 
         metrics = self.pool.get_threads_metrics()

--- a/tests/asyncio/asyncio_threadpool_executor_metrics_test.py
+++ b/tests/asyncio/asyncio_threadpool_executor_metrics_test.py
@@ -1,0 +1,198 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for AsyncioThreadPoolExecutor.get_threads_metrics().
+
+The class wraps every submitted callable to count running tasks, so the
+returned (num_threads, num_running) tuple should accurately reflect both
+the lazy ThreadPoolExecutor worker-thread count and the count of
+callables currently executing in those workers.
+"""
+import threading
+
+from unittest import TestCase
+
+from leaf_common.asyncio.asyncio_threadpool_executor import AsyncioThreadPoolExecutor
+
+
+# Module-level helpers (no nested defs inside test methods).
+def block_on_event(start_event: threading.Event,
+                   release_event: threading.Event):
+    """
+    Helper task body: signals start_event when picked up by a worker thread,
+    then blocks on release_event until the test side releases it. Used to
+    pin one worker thread in the "running" state long enough for the test
+    to observe the metric.
+    """
+    start_event.set()
+    release_event.wait(timeout=5.0)
+
+
+def quick_noop():
+    """Helper task body: returns immediately. Used to force lazy worker creation."""
+
+
+class AsyncioThreadPoolExecutorMetricsTest(TestCase):
+    """
+    Verifies that get_threads_metrics() returns an accurate (threads, running)
+    tuple in each lifecycle state: empty, mid-task, post-task, and under
+    multi-task concurrency.
+    """
+
+    def setUp(self):
+        """Create a fresh executor sized so concurrency tests fit within it."""
+        self.executor = AsyncioThreadPoolExecutor(max_workers=4)
+
+    def tearDown(self):
+        """Always shutdown the executor; tests may leave futures pending on failure."""
+        self.executor.shutdown(wait=True)
+
+    def test_metrics_on_fresh_executor_report_zero_running(self):
+        """
+        Before any work is submitted the executor has lazily created no
+        worker threads and has nothing running, so both counts are 0.
+        """
+        num_threads, num_running = self.executor.get_threads_metrics()
+        self.assertEqual(
+            0, num_threads,
+            f"Expected 0 worker threads on a fresh executor, got {num_threads}.",
+        )
+        self.assertEqual(
+            0, num_running,
+            f"Expected 0 running tasks on a fresh executor, got {num_running}.",
+        )
+
+    def test_metrics_report_one_running_during_task(self):
+        """
+        While a single submitted task is blocked inside its callable,
+        get_threads_metrics() should report exactly 1 running task. The
+        worker-thread count should be at least 1 (ThreadPoolExecutor
+        lazily creates a worker on first submit).
+        """
+        start_event = threading.Event()
+        release_event = threading.Event()
+        future = self.executor.submit(block_on_event, start_event, release_event)
+        # Wait until the worker has actually entered the wrapped callable.
+        self.assertTrue(
+            start_event.wait(timeout=5.0),
+            "Helper task never entered its body within 5s; worker pool stuck?",
+        )
+
+        num_threads, num_running = self.executor.get_threads_metrics()
+
+        # Release the task and wait for it to complete before asserting,
+        # so a failure in the asserts does not leak a blocked worker.
+        release_event.set()
+        future.result(timeout=5.0)
+
+        self.assertGreaterEqual(
+            num_threads, 1,
+            f"Expected at least 1 worker thread mid-task, got {num_threads}.",
+        )
+        self.assertEqual(
+            1, num_running,
+            f"Expected exactly 1 running task while the helper was blocked, "
+            f"got {num_running}.",
+        )
+
+    def test_metrics_running_returns_to_zero_after_task_completes(self):
+        """
+        After a submitted task completes, running should fall back to 0.
+        num_threads stays at whatever the pool grew to (typically 1).
+        """
+        future = self.executor.submit(quick_noop)
+        future.result(timeout=5.0)
+
+        num_threads, num_running = self.executor.get_threads_metrics()
+
+        self.assertGreaterEqual(
+            num_threads, 1,
+            f"Expected at least 1 worker thread after first submit, got {num_threads}.",
+        )
+        self.assertEqual(
+            0, num_running,
+            f"Expected 0 running tasks after task completion, got {num_running}.",
+        )
+
+    def test_metrics_running_count_matches_concurrent_task_count(self):
+        """
+        Submitting N concurrent blocking tasks should result in
+        num_running == N (up to max_workers, which is 4 here).
+        Confirms the wrapper's increment/decrement is per-task, not a
+        single boolean.
+        """
+        concurrent = 3
+        start_events = [threading.Event() for _ in range(concurrent)]
+        release_event = threading.Event()
+        futures = [
+            self.executor.submit(block_on_event, start_events[i], release_event)
+            for i in range(concurrent)
+        ]
+        for i, start_event in enumerate(start_events):
+            self.assertTrue(
+                start_event.wait(timeout=5.0),
+                f"Helper task {i} never entered its body within 5s.",
+            )
+
+        num_threads, num_running = self.executor.get_threads_metrics()
+
+        # Release all tasks and wait for completion before asserting so
+        # a failure does not leak blocked workers.
+        release_event.set()
+        for future in futures:
+            future.result(timeout=5.0)
+
+        self.assertGreaterEqual(
+            num_threads, concurrent,
+            f"Expected at least {concurrent} worker threads, got {num_threads}.",
+        )
+        self.assertEqual(
+            concurrent, num_running,
+            f"Expected {concurrent} running tasks while helpers were blocked, "
+            f"got {num_running}.",
+        )
+
+    def test_metrics_handles_missing_threads_attribute_gracefully(self):
+        """
+        get_threads_metrics() reaches into the protected _threads member
+        of ThreadPoolExecutor; if a future stdlib version removes it the
+        method should fall back to 0 rather than raising. We simulate
+        that by clearing the attribute via delattr.
+        """
+        # First submit one task so the executor would normally have threads.
+        self.executor.submit(quick_noop).result(timeout=5.0)
+        # Snapshot and remove _threads to simulate the missing-attribute
+        # environment, then restore it in finally so tearDown's shutdown
+        # (which also reads _threads) can still succeed.
+        # pylint: disable=protected-access
+        saved_threads = self.executor._threads
+        del self.executor._threads
+        try:
+            num_threads, num_running = self.executor.get_threads_metrics()
+        finally:
+            self.executor._threads = saved_threads
+
+        self.assertEqual(
+            0, num_threads,
+            f"Expected fallback of 0 worker threads when _threads is missing, "
+            f"got {num_threads}.",
+        )
+        self.assertEqual(
+            0, num_running,
+            f"Expected 0 running tasks after the only submitted task finished, "
+            f"got {num_running}.",
+        )

--- a/tests/asyncio/asyncio_threadpool_executor_metrics_test.py
+++ b/tests/asyncio/asyncio_threadpool_executor_metrics_test.py
@@ -27,23 +27,7 @@ import threading
 from unittest import TestCase
 
 from leaf_common.asyncio.asyncio_threadpool_executor import AsyncioThreadPoolExecutor
-
-
-# Module-level helpers (no nested defs inside test methods).
-def block_on_event(start_event: threading.Event,
-                   release_event: threading.Event):
-    """
-    Helper task body: signals start_event when picked up by a worker thread,
-    then blocks on release_event until the test side releases it. Used to
-    pin one worker thread in the "running" state long enough for the test
-    to observe the metric.
-    """
-    start_event.set()
-    release_event.wait(timeout=5.0)
-
-
-def quick_noop():
-    """Helper task body: returns immediately. Used to force lazy worker creation."""
+from tests.asyncio.sync_test_helpers import SyncTestHelpers
 
 
 class AsyncioThreadPoolExecutorMetricsTest(TestCase):
@@ -52,6 +36,10 @@ class AsyncioThreadPoolExecutorMetricsTest(TestCase):
     tuple in each lifecycle state: empty, mid-task, post-task, and under
     multi-task concurrency.
     """
+
+    @staticmethod
+    def quick_noop():
+        """Helper task body: returns immediately. Used to force lazy worker creation."""
 
     def setUp(self):
         """Create a fresh executor sized so concurrency tests fit within it."""
@@ -85,7 +73,7 @@ class AsyncioThreadPoolExecutorMetricsTest(TestCase):
         """
         start_event = threading.Event()
         release_event = threading.Event()
-        future = self.executor.submit(block_on_event, start_event, release_event)
+        future = self.executor.submit(SyncTestHelpers.block_on_event, start_event, release_event)
         # Wait until the worker has actually entered the wrapped callable.
         self.assertTrue(
             start_event.wait(timeout=5.0),
@@ -114,7 +102,7 @@ class AsyncioThreadPoolExecutorMetricsTest(TestCase):
         After a submitted task completes, running should fall back to 0.
         num_threads stays at whatever the pool grew to (typically 1).
         """
-        future = self.executor.submit(quick_noop)
+        future = self.executor.submit(self.quick_noop)
         future.result(timeout=5.0)
 
         num_threads, num_running = self.executor.get_threads_metrics()
@@ -139,7 +127,7 @@ class AsyncioThreadPoolExecutorMetricsTest(TestCase):
         start_events = [threading.Event() for _ in range(concurrent)]
         release_event = threading.Event()
         futures = [
-            self.executor.submit(block_on_event, start_events[i], release_event)
+            self.executor.submit(SyncTestHelpers.block_on_event, start_events[i], release_event)
             for i in range(concurrent)
         ]
         for i, start_event in enumerate(start_events):
@@ -174,7 +162,7 @@ class AsyncioThreadPoolExecutorMetricsTest(TestCase):
         that by clearing the attribute via delattr.
         """
         # First submit one task so the executor would normally have threads.
-        self.executor.submit(quick_noop).result(timeout=5.0)
+        self.executor.submit(self.quick_noop).result(timeout=5.0)
         # Snapshot and remove _threads to simulate the missing-attribute
         # environment, then restore it in finally so tearDown's shutdown
         # (which also reads _threads) can still succeed.

--- a/tests/asyncio/sync_test_helpers.py
+++ b/tests/asyncio/sync_test_helpers.py
@@ -64,3 +64,14 @@ class SyncTestHelpers:
         Custom callback that signals when called.
         """
         callback_called.set()
+
+    @staticmethod
+    def block_on_event(start_event, release_event):
+        """
+        Helper task body for thread-pool metrics tests: signals start_event
+        when the calling worker thread enters the body, then blocks on
+        release_event until the test side releases it. Lets a test pin one
+        worker in the "running" state long enough to observe the metric.
+        """
+        start_event.set()
+        release_event.wait(timeout=5.0)


### PR DESCRIPTION
This PR extends run-time metrics we can provide for collection of AsyncioExecutors:

1. Add new class AsyncioThreadPoolExecutor - which is sub-class of ThreadPoolExecutor instrumented for collecting additional metrics of currently actively running threads (not just created in this pool)
2. In addition to keeping pool of AsyncioExecutors available for deployment we keep collection of AsyncioExecutors currently used - deployed for client request execution;
3. For each AsyncioExecutor from either collection, we provide run-time metrics of how many threads were created in a thread pool linked to AsyncioExecutor own event loop, and how many of them are actively running
4. AsyncioExecutorPool now has get_threads_metrics() method providing metrics for both of "available" and "used" AsyncioExecutors collection: number of instances in this collection, number of work threads created for this collection and number of threads which are actively running.
