### PR TITLE
NSS-1120 Platform-specific event loop factory.

### DIFF
--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -36,6 +36,7 @@ from asyncio import Future
 from asyncio import Task
 from concurrent import futures
 
+from leaf_common.asyncio.event_loop_factory import EventLoopFactory
 from leaf_common.asyncio.task_executor import TaskExecutor
 from leaf_common.asyncio.asyncio_threadpool_executor import AsyncioThreadPoolExecutor
 
@@ -60,7 +61,7 @@ class AsyncioExecutor(TaskExecutor):
         # We are going to start new thread for this Executor,
         # so we need a new event loop bound to this particular thread:
         self._threadpool_executor: AsyncioThreadPoolExecutor = AsyncioThreadPoolExecutor()
-        self._loop: AbstractEventLoop = asyncio.new_event_loop()
+        self._loop: AbstractEventLoop = EventLoopFactory.new_event_loop()
         self._loop.set_exception_handler(AsyncioExecutor.loop_exception_handler)
         self._loop.set_default_executor(self._threadpool_executor)
         self._loop_ready = threading.Event()

--- a/leaf_common/asyncio/event_loop_factory.py
+++ b/leaf_common/asyncio/event_loop_factory.py
@@ -17,12 +17,13 @@
 """
 See class comment for details.
 """
+from typing import Callable
+from typing import Optional
+
 import asyncio
 import sys
 
 from asyncio import AbstractEventLoop
-from typing import Callable
-from typing import Optional
 
 
 class EventLoopFactory:

--- a/leaf_common/asyncio/event_loop_factory.py
+++ b/leaf_common/asyncio/event_loop_factory.py
@@ -1,0 +1,89 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+import asyncio
+import sys
+
+from asyncio import AbstractEventLoop
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import Optional
+
+
+class EventLoopFactory:
+    """
+    Factory for creating asyncio event loops with a platform-appropriate type.
+
+    On Windows the factory produces SelectorEventLoop instances; on other
+    platforms it defers to asyncio's platform default. This is the
+    forward-compatible replacement for the asyncio.set_event_loop_policy()
+    pattern (using asyncio.WindowsSelectorEventLoopPolicy on Windows), which
+    is deprecated in Python 3.14 and slated for removal.
+
+    Three entry points are provided so callers can pick what matches their
+    existing call site:
+      - loop_factory(): returns a callable suitable for the loop_factory=
+            keyword on asyncio.run() and asyncio.Runner(). Returns None on
+            platforms where asyncio's default is appropriate; None is the
+            documented sentinel for "use default", so the result can be
+            passed through unchanged on any platform.
+      - new_event_loop(): drop-in replacement for asyncio.new_event_loop()
+            at sites that construct a loop directly.
+      - run(): drop-in replacement for asyncio.run().
+    """
+
+    @staticmethod
+    def loop_factory() -> Optional[Callable[[], AbstractEventLoop]]:
+        """
+        :return: A callable that constructs a platform-appropriate event
+                 loop, or None if asyncio's default is appropriate. None is
+                 the documented value asyncio.run() and asyncio.Runner()
+                 accept to mean "use the default factory", so the return
+                 value of this method can be forwarded unchanged on any
+                 platform.
+        """
+        if sys.platform == "win32":
+            return asyncio.SelectorEventLoop
+        return None
+
+    @staticmethod
+    def new_event_loop() -> AbstractEventLoop:
+        """
+        :return: A newly-constructed event loop appropriate for the current
+                 platform. On Windows this is a SelectorEventLoop; on other
+                 platforms it is the loop type returned by
+                 asyncio.new_event_loop().
+        """
+        factory: Optional[Callable[[], AbstractEventLoop]] = EventLoopFactory.loop_factory()
+        if factory is not None:
+            return factory()
+        return asyncio.new_event_loop()
+
+    @staticmethod
+    def run(main: Awaitable, *, debug: Optional[bool] = None) -> Any:
+        """
+        Drop-in replacement for asyncio.run() that uses a platform-appropriate
+        loop type.
+
+        :param main: The coroutine to run.
+        :param debug: Optional debug flag, passed through to asyncio.run().
+        :return: The result of the coroutine.
+        """
+        return asyncio.run(main, debug=debug, loop_factory=EventLoopFactory.loop_factory())

--- a/leaf_common/asyncio/event_loop_factory.py
+++ b/leaf_common/asyncio/event_loop_factory.py
@@ -21,8 +21,6 @@ import asyncio
 import sys
 
 from asyncio import AbstractEventLoop
-from typing import Any
-from typing import Awaitable
 from typing import Callable
 from typing import Optional
 
@@ -37,16 +35,18 @@ class EventLoopFactory:
     pattern (using asyncio.WindowsSelectorEventLoopPolicy on Windows), which
     is deprecated in Python 3.14 and slated for removal.
 
-    Three entry points are provided so callers can pick what matches their
+    Two entry points are provided so callers can pick what matches their
     existing call site:
       - loop_factory(): returns a callable suitable for the loop_factory=
-            keyword on asyncio.run() and asyncio.Runner(). Returns None on
-            platforms where asyncio's default is appropriate; None is the
-            documented sentinel for "use default", so the result can be
-            passed through unchanged on any platform.
+            keyword on asyncio.run() (Python 3.12+) and asyncio.Runner()
+            (Python 3.11+). Returns None on platforms where asyncio's
+            default is appropriate; None is the documented sentinel for
+            "use default", so the result can be passed through unchanged
+            on any platform.
       - new_event_loop(): drop-in replacement for asyncio.new_event_loop()
-            at sites that construct a loop directly.
-      - run(): drop-in replacement for asyncio.run().
+            at sites that construct a loop directly. Combine with
+            asyncio.set_event_loop() to install the loop for the current
+            thread before frameworks (e.g. Tornado) wrap it.
     """
 
     @staticmethod
@@ -75,15 +75,3 @@ class EventLoopFactory:
         if factory is not None:
             return factory()
         return asyncio.new_event_loop()
-
-    @staticmethod
-    def run(main: Awaitable, *, debug: Optional[bool] = None) -> Any:
-        """
-        Drop-in replacement for asyncio.run() that uses a platform-appropriate
-        loop type.
-
-        :param main: The coroutine to run.
-        :param debug: Optional debug flag, passed through to asyncio.run().
-        :return: The result of the coroutine.
-        """
-        return asyncio.run(main, debug=debug, loop_factory=EventLoopFactory.loop_factory())

--- a/leaf_common/asyncio/event_loop_factory.py
+++ b/leaf_common/asyncio/event_loop_factory.py
@@ -30,11 +30,11 @@ class EventLoopFactory:
     """
     Factory for creating asyncio event loops with a platform-appropriate type.
 
-    On Windows the factory produces SelectorEventLoop instances; on other
-    platforms it defers to asyncio's platform default. This is the
-    forward-compatible replacement for the asyncio.set_event_loop_policy()
-    pattern (using asyncio.WindowsSelectorEventLoopPolicy on Windows), which
-    is deprecated in Python 3.14 and slated for removal.
+    On Windows the factory produces SelectorEventLoop instances (note: this loop
+    does not support asyncio subprocess APIs); on other platforms it defers to
+    asyncio's platform default. This is the forward-compatible replacement for the
+    asyncio.set_event_loop_policy() pattern (using asyncio.WindowsSelectorEventLoopPolicy
+    on Windows), which is deprecated in Python 3.14 and slated for removal.
 
     Two entry points are provided so callers can pick what matches their
     existing call site:

--- a/tests/asyncio/event_loop_factory_test.py
+++ b/tests/asyncio/event_loop_factory_test.py
@@ -1,0 +1,94 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for EventLoopFactory's platform-selection behavior.
+
+These tests patch sys.platform so the Windows branch can be exercised on a
+non-Windows test runner without requiring a Windows-only CI job.
+"""
+
+import asyncio
+import sys
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from leaf_common.asyncio.event_loop_factory import EventLoopFactory
+
+
+class EventLoopFactoryTest(TestCase):
+    """
+    Tests for EventLoopFactory.loop_factory() and EventLoopFactory.new_event_loop()
+    under various emulated sys.platform values.
+    """
+
+    def test_loop_factory_returns_selector_loop_class_on_windows(self):
+        """
+        On Windows (sys.platform == 'win32'), loop_factory() returns the
+        asyncio.SelectorEventLoop class as the factory callable.
+        """
+        with patch.object(sys, "platform", "win32"):
+            self.assertIs(EventLoopFactory.loop_factory(), asyncio.SelectorEventLoop)
+
+    def test_loop_factory_returns_none_on_linux(self):
+        """
+        On Linux (sys.platform == 'linux'), loop_factory() returns None so
+        callers defer to asyncio's platform default.
+        """
+        with patch.object(sys, "platform", "linux"):
+            self.assertIsNone(EventLoopFactory.loop_factory())
+
+    def test_loop_factory_returns_none_on_macos(self):
+        """
+        On macOS (sys.platform == 'darwin'), loop_factory() returns None so
+        callers defer to asyncio's platform default.
+        """
+        with patch.object(sys, "platform", "darwin"):
+            self.assertIsNone(EventLoopFactory.loop_factory())
+
+    def test_loop_factory_returns_none_on_cygwin(self):
+        """
+        On Cygwin (sys.platform == 'cygwin', a Unix-like Windows environment),
+        loop_factory() returns None: only the exact value 'win32' triggers
+        the Selector override.
+        """
+        with patch.object(sys, "platform", "cygwin"):
+            self.assertIsNone(EventLoopFactory.loop_factory())
+
+    def test_new_event_loop_constructs_selector_loop_on_emulated_windows(self):
+        """
+        new_event_loop() constructs an asyncio.SelectorEventLoop instance
+        when sys.platform is emulated as 'win32'.
+        """
+        with patch.object(sys, "platform", "win32"):
+            loop = EventLoopFactory.new_event_loop()
+            try:
+                self.assertIsInstance(loop, asyncio.SelectorEventLoop)
+            finally:
+                loop.close()
+
+    def test_new_event_loop_returns_default_loop_on_non_windows(self):
+        """
+        new_event_loop() returns an AbstractEventLoop instance (the platform
+        default) when sys.platform is emulated as a non-Windows value.
+        """
+        with patch.object(sys, "platform", "linux"):
+            loop = EventLoopFactory.new_event_loop()
+            try:
+                self.assertIsInstance(loop, asyncio.AbstractEventLoop)
+            finally:
+                loop.close()

--- a/tests/serialization/encoding/text_file_reader_test.py
+++ b/tests/serialization/encoding/text_file_reader_test.py
@@ -18,11 +18,11 @@
 See class comment for details.
 """
 
+import asyncio
 import os
 import tempfile
 from unittest import TestCase
 
-from leaf_common.asyncio.event_loop_factory import EventLoopFactory
 from leaf_common.serialization.util.text_file_reader import TextFileReader
 
 
@@ -108,31 +108,31 @@ class TextFileReaderTest(TestCase):
     def test_async_read_text_file_decodes_utf8(self):
         """A UTF-8 encoded file is decoded via the utf-8 branch (async)."""
         path = self._write_bytes(UTF8_BYTES)
-        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
+        result = asyncio.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, UTF8_EXPECTED)
 
     def test_async_read_text_file_decodes_cp1252(self):
         """A cp1252-only byte sequence falls through utf-8 and is decoded as cp1252 (async)."""
         path = self._write_bytes(CP1252_BYTES)
-        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
+        result = asyncio.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, CP1252_EXPECTED)
 
     def test_async_read_text_file_decodes_latin1(self):
         """A latin-1-only byte sequence falls through utf-8 and cp1252, decoded as latin-1 (async)."""
         path = self._write_bytes(LATIN1_BYTES)
-        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
+        result = asyncio.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, LATIN1_EXPECTED)
 
     def test_async_read_text_file_empty_file_returns_empty_string(self):
         """An empty file decodes to an empty string (async)."""
         path = self._write_bytes(b"")
-        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
+        result = asyncio.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, "")
 
     def test_async_read_text_file_raises_file_not_found(self):
         """A missing file raises FileNotFoundError (async)."""
         with self.assertRaises(FileNotFoundError):
-            EventLoopFactory.run(
+            asyncio.run(
                 TextFileReader.async_read_text_file(
                     os.path.join(self.tmp_path, "does_not_exist.txt")
                 )

--- a/tests/serialization/encoding/text_file_reader_test.py
+++ b/tests/serialization/encoding/text_file_reader_test.py
@@ -18,11 +18,11 @@
 See class comment for details.
 """
 
-import asyncio
 import os
 import tempfile
 from unittest import TestCase
 
+from leaf_common.asyncio.event_loop_factory import EventLoopFactory
 from leaf_common.serialization.util.text_file_reader import TextFileReader
 
 
@@ -108,31 +108,31 @@ class TextFileReaderTest(TestCase):
     def test_async_read_text_file_decodes_utf8(self):
         """A UTF-8 encoded file is decoded via the utf-8 branch (async)."""
         path = self._write_bytes(UTF8_BYTES)
-        result = asyncio.run(TextFileReader.async_read_text_file(path))
+        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, UTF8_EXPECTED)
 
     def test_async_read_text_file_decodes_cp1252(self):
         """A cp1252-only byte sequence falls through utf-8 and is decoded as cp1252 (async)."""
         path = self._write_bytes(CP1252_BYTES)
-        result = asyncio.run(TextFileReader.async_read_text_file(path))
+        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, CP1252_EXPECTED)
 
     def test_async_read_text_file_decodes_latin1(self):
         """A latin-1-only byte sequence falls through utf-8 and cp1252, decoded as latin-1 (async)."""
         path = self._write_bytes(LATIN1_BYTES)
-        result = asyncio.run(TextFileReader.async_read_text_file(path))
+        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, LATIN1_EXPECTED)
 
     def test_async_read_text_file_empty_file_returns_empty_string(self):
         """An empty file decodes to an empty string (async)."""
         path = self._write_bytes(b"")
-        result = asyncio.run(TextFileReader.async_read_text_file(path))
+        result = EventLoopFactory.run(TextFileReader.async_read_text_file(path))
         self.assertEqual(result, "")
 
     def test_async_read_text_file_raises_file_not_found(self):
         """A missing file raises FileNotFoundError (async)."""
         with self.assertRaises(FileNotFoundError):
-            asyncio.run(
+            EventLoopFactory.run(
                 TextFileReader.async_read_text_file(
                     os.path.join(self.tmp_path, "does_not_exist.txt")
                 )


### PR DESCRIPTION
This PR adds EventLoopFactory class which encapsulates platform-specific policies for creating new asyncio event loops.
Specifically, for win32 platform we are creating asyncio.SelectorEventLoop event loop instead of Windows default,
which proved to be problematic for neuro-san service.
This EventLoopFactory class also future-proofs us for changes in event loops construction logic,
already present in Python 12 and scheduled to be mandatory in Python 14 and 16.
