### PR TITLE
NS-1022 Garbage-collect unused AsyncioExecutors.

### DIFF
--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -223,7 +223,7 @@ class AsyncioExecutorPool:
                 executor.shutdown(wait=True)
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 self.logger.warning(
-                    "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc)
+                    "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc, exc_info=True)
 
     def _sweep_once(self, now: Optional[float] = None) -> None:
         """

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -55,9 +55,11 @@ class AsyncioExecutorPool:
     DEFAULT_IDLE_TIMEOUT_SECONDS and DEFAULT_GC_SWEEP_INTERVAL_SECONDS.
 
     Lifecycle: callers should invoke shutdown() to stop the GC thread when
-    the pool is no longer needed. The GC thread is a daemon so it will not
-    block process exit if shutdown() is not called, but explicit shutdown
-    is cleaner for tests and managed long-running services.
+    the pool is no longer needed. The GC thread holds a strong reference to
+    the pool, so omitting shutdown() will keep the pool (and its state) alive
+    for the lifetime of the process. The GC thread is a daemon so it will not
+    block process exit, but explicit shutdown is cleaner for tests and managed
+    long-running services.
     """
 
     # Internal configuration: default idle time (seconds) after which an

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -76,6 +76,7 @@ class AsyncioExecutorPool:
                                  are taken from pool of available ones (pool mode);
                            False, if requested executor instances are created new
                                  and shutdown on return (backward compatible mode)
+        Note that 2 parameters below are keyword-only, to make it more explicit when configuring the GC policy.
         :param idle_timeout_seconds: Idle time threshold in seconds. An
                                  AsyncioExecutor sitting in pool_available
                                  longer than this is shut down and removed

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -19,47 +19,117 @@ See class comments
 """
 from typing import Any
 from typing import Dict
+from typing import List
+from typing import Optional
 
 import copy
 import logging
+import queue
 import threading
+import time
+
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
 
 
 class AsyncioExecutorPool:
+    # pylint: disable=too-many-instance-attributes
     """
     Class maintaining a dynamic set of reusable AsyncioExecutor instances.
+
+    Garbage collection policy
+    -------------------------
+    When reuse_mode is True, executors are returned to pool_available rather
+    than shut down. Each time an executor is returned, its return timestamp
+    is recorded. On every subsequent get_executor() or return_executor()
+    call, the pool sweeps pool_available and identifies any executor whose
+    idle period exceeds idle_timeout_seconds. The sweep is passive (no
+    polling thread): a fully-idle pool will not collect on its own, but
+    any activity on the pool reaps stale executors.
+
+    The sweep itself is fast: it only mutates pool_available / _returned_at
+    under the pool lock. The expensive AsyncioExecutor.shutdown(wait=True)
+    call is enqueued onto _gc_queue and performed asynchronously on a
+    dedicated daemon GC thread. This keeps the caller of get_executor /
+    return_executor off the shutdown latency path.
+
+    The idle threshold is internally configurable via the
+    idle_timeout_seconds constructor parameter, with the default given by
+    DEFAULT_IDLE_TIMEOUT_SECONDS.
+
+    Lifecycle: callers should invoke shutdown() to drain the GC queue and
+    stop the background GC thread when the pool is no longer needed. The
+    GC thread is a daemon so it will not block process exit if shutdown()
+    is not called, but explicit shutdown is cleaner for tests and managed
+    long-running services.
     """
 
-    def __init__(self, reuse_mode: bool = True):
+    # Internal configuration: default idle time (seconds) after which an
+    # executor sitting in pool_available is shut down and removed.
+    DEFAULT_IDLE_TIMEOUT_SECONDS: float = 3 * 60.0
+
+    def __init__(self, reuse_mode: bool = True,
+                 idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS):
         """
         Constructor.
         :param reuse_mode: True, if requested executor instances
                                  are taken from pool of available ones (pool mode);
                            False, if requested executor instances are created new
                                  and shutdown on return (backward compatible mode)
+        :param idle_timeout_seconds: Idle time threshold in seconds. An
+                                 AsyncioExecutor sitting in pool_available
+                                 longer than this is dropped from the pool
+                                 by the passive sweep and shut down by the
+                                 background GC thread. Only applies when
+                                 reuse_mode is True.
         """
         self.reuse_mode: bool = reuse_mode
+        self.idle_timeout_seconds: float = idle_timeout_seconds
+
         # List of available (not currently used) AsyncioExecutor instances in the pool.
-        self.pool_available = []
+        self.pool_available: List[AsyncioExecutor] = []
 
         # List of currently used AsyncioExecutor instances in the pool.
-        self.pool_used = []
+        self.pool_used: List[AsyncioExecutor] = []
+
+        # Maps id(executor) -> monotonic timestamp when the executor was
+        # returned to pool_available. Only contains entries for executors
+        # currently in pool_available; pruned on get_executor() and on sweep.
+        self._returned_at: Dict[int, float] = {}
 
         self.lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.logger.debug("AsyncioExecutorPool created: %s reuse: %s",
-                          id(self), str(self.reuse_mode))
+
+        # Hybrid GC: the sweep mutates the pool in the caller's thread, then
+        # enqueues stale executors here for the background GC thread to
+        # shut down off the request path.
+        self._gc_queue: queue.Queue = queue.Queue()
+        self._gc_thread: Optional[threading.Thread] = None
+        if self.reuse_mode:
+            self._gc_thread = threading.Thread(
+                target=self._gc_loop,
+                name=f"AsyncioExecutorPool-GC-{id(self)}",
+                daemon=True,
+            )
+            self._gc_thread.start()
+
+        self.logger.debug("AsyncioExecutorPool created: %s reuse: %s idle_timeout: %.1fs",
+                          id(self), str(self.reuse_mode), self.idle_timeout_seconds)
 
     def get_executor(self) -> AsyncioExecutor:
         """
-        Get active (running) executor from the pool
+        Get active (running) executor from the pool.
+        Triggers a passive GC sweep of pool_available before deciding
+        whether to reuse an existing executor or construct a new one.
         :return: AsyncioExecutor instance
         """
+        # Reap stale executors first; the available pool may be empty after this.
+        self._collect_idle_executors()
+
         if self.reuse_mode:
             with self.lock:
                 if len(self.pool_available) > 0:
                     result = self.pool_available.pop(0)
+                    self._returned_at.pop(id(result), None)
                     self.logger.debug("Reusing AsyncioExecutor %s", id(result))
                     self.pool_used.append(result)
                     return result
@@ -92,8 +162,90 @@ class AsyncioExecutorPool:
         if self.reuse_mode:
             with self.lock:
                 self.pool_available.append(executor)
+                self._returned_at[id(executor)] = time.monotonic()
                 self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d",
                                   id(executor), len(self.pool_available))
+            # Sweep AFTER recording so any accumulated stale entries get reaped on activity.
+            self._collect_idle_executors()
+
+    def shutdown(self) -> None:
+        """
+        Drain the GC queue and stop the background GC thread. After this
+        returns, the pool no longer reaps idle executors. Idempotent.
+        Executors still held in pool_used or pool_available are NOT shut
+        down here; callers that want those gone should handle them
+        explicitly.
+        """
+        if self._gc_thread is None:
+            return
+        # Drain the queue - wait for all currently-pending shutdowns to complete.
+        self._gc_queue.join()
+        # Signal the GC thread to exit, then wait for it.
+        self._gc_queue.put(None)
+        self._gc_thread.join()
+        self._gc_thread = None
+
+    def _collect_idle_executors(self, now: Optional[float] = None) -> None:
+        """
+        Identify any executors in pool_available whose idle time exceeds
+        idle_timeout_seconds, remove them from the pool, and enqueue them
+        for shutdown on the background GC thread.
+
+        No-op when not in reuse mode (non-reuse mode shuts executors down
+        on return, so pool_available is always empty in that mode).
+
+        pool_available is FIFO-ordered by return time (oldest at the head),
+        so the scan stops at the first non-stale entry.
+
+        :param now: Optional override for the current time, in the same
+                    units as time.monotonic(). Intended for tests; production
+                    callers should omit this and let it default to
+                    time.monotonic().
+        """
+        if not self.reuse_mode:
+            return
+        if now is None:
+            now = time.monotonic()
+        to_collect: List[AsyncioExecutor] = []
+        with self.lock:
+            keep_from: int = 0
+            for executor in self.pool_available:
+                returned_at: float = self._returned_at.get(id(executor), now)
+                if now - returned_at > self.idle_timeout_seconds:
+                    to_collect.append(executor)
+                    keep_from += 1
+                else:
+                    break
+            if keep_from > 0:
+                for executor in self.pool_available[:keep_from]:
+                    self._returned_at.pop(id(executor), None)
+                del self.pool_available[:keep_from]
+        # Enqueue stale executors for asynchronous shutdown. queue.Queue.put()
+        # is O(1) and non-blocking on an unbounded queue, so the caller pays
+        # only the cost of the list/dict mutations under the lock above.
+        for executor in to_collect:
+            self._gc_queue.put(executor)
+
+    def _gc_loop(self) -> None:
+        """
+        Background loop draining _gc_queue and shutting down each stale
+        executor. Exits when a None sentinel is dequeued via shutdown().
+        Exceptions are logged but do not stop the loop, so a single bad
+        executor cannot leak the rest.
+        """
+        while True:
+            executor: Optional[AsyncioExecutor] = self._gc_queue.get()
+            try:
+                if executor is None:
+                    break
+                try:
+                    self.logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
+                    executor.shutdown(wait=True)
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    self.logger.warning(
+                        "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc)
+            finally:
+                self._gc_queue.task_done()
 
     def get_threads_metrics(self) -> Dict[str, Any]:
         """

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -180,20 +180,23 @@ class AsyncioExecutorPool:
                 self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d",
                                   id(executor), len(self.pool_available))
 
-    def shutdown(self) -> None:
+    def shutdown(self, wait: bool = True) -> None:
         """
         Stop the background GC thread. After this returns, the pool no
         longer reaps idle executors. Idempotent. Executors still held in
         pool_used or pool_available are NOT shut down here; callers that
         want those gone should handle them explicitly.
         """
-        if self._gc_thread is None:
-            return
-        self._gc_stop_event.set()
-        if threading.current_thread() is not self._gc_thread:
-            self._gc_thread.join()
-        self._gc_thread = None
+        with self.lock:
+            gc_thread = self._gc_thread
+            if gc_thread is None:
+                return
+            # Clear first to make concurrent shutdown() calls safe.
+            self._gc_thread = None
 
+        self._gc_stop_event.set()
+        if wait and threading.current_thread() is not gc_thread:
+            gc_thread.join()
     def _gc_loop(self) -> None:
         """
         Active GC loop: sweep, then wait for either the configured

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -197,6 +197,7 @@ class AsyncioExecutorPool:
         self._gc_stop_event.set()
         if wait and threading.current_thread() is not gc_thread:
             gc_thread.join()
+
     def _gc_loop(self) -> None:
         """
         Active GC loop: sweep, then wait for either the configured

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -189,7 +189,8 @@ class AsyncioExecutorPool:
         if self._gc_thread is None:
             return
         self._gc_stop_event.set()
-        self._gc_thread.join()
+        if threading.current_thread() is not self._gc_thread:
+            self._gc_thread.join()
         self._gc_thread = None
 
     def _gc_loop(self) -> None:

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -91,7 +91,11 @@ class AsyncioExecutorPool:
         self.reuse_mode: bool = reuse_mode
         self.idle_timeout_seconds: float = idle_timeout_seconds
         self.gc_sweep_interval_seconds: float = gc_sweep_interval_seconds
-
+        if self.reuse_mode:
+            if self.gc_sweep_interval_seconds <= 0:
+                raise ValueError("gc_sweep_interval_seconds must be > 0 when reuse_mode=True")
+            if self.idle_timeout_seconds < 0:
+                raise ValueError("idle_timeout_seconds must be >= 0 when reuse_mode=True")
         # List of available (not currently used) AsyncioExecutor instances in the pool.
         self.pool_available: List[AsyncioExecutor] = []
 

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -24,7 +24,6 @@ from typing import Optional
 
 import copy
 import logging
-import queue
 import threading
 import time
 
@@ -40,35 +39,37 @@ class AsyncioExecutorPool:
     -------------------------
     When reuse_mode is True, executors are returned to pool_available rather
     than shut down. Each time an executor is returned, its return timestamp
-    is recorded. On every subsequent get_executor() or return_executor()
-    call, the pool sweeps pool_available and identifies any executor whose
-    idle period exceeds idle_timeout_seconds. The sweep is passive (no
-    polling thread): a fully-idle pool will not collect on its own, but
-    any activity on the pool reaps stale executors.
+    is recorded.
 
-    The sweep itself is fast: it only mutates pool_available / _returned_at
-    under the pool lock. The expensive AsyncioExecutor.shutdown(wait=True)
-    call is enqueued onto _gc_queue and performed asynchronously on a
-    dedicated daemon GC thread. This keeps the caller of get_executor /
-    return_executor off the shutdown latency path.
+    Garbage collection is performed by a dedicated daemon GC thread that
+    runs on its own schedule, independent of any get_executor() /
+    return_executor() activity. Every gc_sweep_interval_seconds the thread
+    wakes, identifies any executor whose idle period exceeds
+    idle_timeout_seconds, removes it from pool_available, and shuts it
+    down. This keeps the caller of get_executor / return_executor off both
+    the sweep and the shutdown latency paths entirely.
 
-    The idle threshold is internally configurable via the
-    idle_timeout_seconds constructor parameter, with the default given by
-    DEFAULT_IDLE_TIMEOUT_SECONDS.
+    Both the idle threshold and the sweep interval are internally
+    configurable via constructor parameters, with defaults given by
+    DEFAULT_IDLE_TIMEOUT_SECONDS and DEFAULT_GC_SWEEP_INTERVAL_SECONDS.
 
-    Lifecycle: callers should invoke shutdown() to drain the GC queue and
-    stop the background GC thread when the pool is no longer needed. The
-    GC thread is a daemon so it will not block process exit if shutdown()
-    is not called, but explicit shutdown is cleaner for tests and managed
-    long-running services.
+    Lifecycle: callers should invoke shutdown() to stop the GC thread when
+    the pool is no longer needed. The GC thread is a daemon so it will not
+    block process exit if shutdown() is not called, but explicit shutdown
+    is cleaner for tests and managed long-running services.
     """
 
     # Internal configuration: default idle time (seconds) after which an
     # executor sitting in pool_available is shut down and removed.
     DEFAULT_IDLE_TIMEOUT_SECONDS: float = 3 * 60.0
 
+    # Internal configuration: default interval (seconds) at which the GC
+    # thread wakes to look for stale executors.
+    DEFAULT_GC_SWEEP_INTERVAL_SECONDS: float = 30.0
+
     def __init__(self, reuse_mode: bool = True,
-                 idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS):
+                 idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS,
+                 gc_sweep_interval_seconds: float = DEFAULT_GC_SWEEP_INTERVAL_SECONDS):
         """
         Constructor.
         :param reuse_mode: True, if requested executor instances
@@ -77,13 +78,19 @@ class AsyncioExecutorPool:
                                  and shutdown on return (backward compatible mode)
         :param idle_timeout_seconds: Idle time threshold in seconds. An
                                  AsyncioExecutor sitting in pool_available
-                                 longer than this is dropped from the pool
-                                 by the passive sweep and shut down by the
-                                 background GC thread. Only applies when
+                                 longer than this is shut down and removed
+                                 by the background GC thread. Only applies
+                                 when reuse_mode is True.
+        :param gc_sweep_interval_seconds: Interval at which the GC thread
+                                 checks pool_available for stale executors.
+                                 Stale executors linger at most one sweep
+                                 interval beyond the idle timeout before
+                                 being collected. Only applies when
                                  reuse_mode is True.
         """
         self.reuse_mode: bool = reuse_mode
         self.idle_timeout_seconds: float = idle_timeout_seconds
+        self.gc_sweep_interval_seconds: float = gc_sweep_interval_seconds
 
         # List of available (not currently used) AsyncioExecutor instances in the pool.
         self.pool_available: List[AsyncioExecutor] = []
@@ -99,10 +106,10 @@ class AsyncioExecutorPool:
         self.lock = threading.Lock()
         self.logger = logging.getLogger(self.__class__.__name__)
 
-        # Hybrid GC: the sweep mutates the pool in the caller's thread, then
-        # enqueues stale executors here for the background GC thread to
-        # shut down off the request path.
-        self._gc_queue: queue.Queue = queue.Queue()
+        # Active GC: a daemon thread runs _gc_loop, sweeping on its own
+        # schedule. The stop event lets shutdown() interrupt the sweep
+        # interval wait promptly.
+        self._gc_stop_event: threading.Event = threading.Event()
         self._gc_thread: Optional[threading.Thread] = None
         if self.reuse_mode:
             self._gc_thread = threading.Thread(
@@ -112,19 +119,19 @@ class AsyncioExecutorPool:
             )
             self._gc_thread.start()
 
-        self.logger.debug("AsyncioExecutorPool created: %s reuse: %s idle_timeout: %.1fs",
-                          id(self), str(self.reuse_mode), self.idle_timeout_seconds)
+        self.logger.debug(
+            "AsyncioExecutorPool created: %s reuse: %s idle_timeout: %.1fs sweep_interval: %.1fs",
+            id(self), str(self.reuse_mode), self.idle_timeout_seconds, self.gc_sweep_interval_seconds)
 
     def get_executor(self) -> AsyncioExecutor:
         """
-        Get active (running) executor from the pool.
-        Triggers a passive GC sweep of pool_available before deciding
-        whether to reuse an existing executor or construct a new one.
+        Get active (running) executor from the pool. Does not sweep;
+        sweeping is the GC thread's responsibility. If a stale executor
+        happens to sit at the head of pool_available before the next
+        sweep, get_executor() will reuse it -- which is fine, since
+        "stale" only means "would otherwise be collected as idle".
         :return: AsyncioExecutor instance
         """
-        # Reap stale executors first; the available pool may be empty after this.
-        self._collect_idle_executors()
-
         if self.reuse_mode:
             with self.lock:
                 if len(self.pool_available) > 0:
@@ -145,6 +152,8 @@ class AsyncioExecutorPool:
     def return_executor(self, executor: AsyncioExecutor):
         """
         Return AsyncioExecutor instance back to the pool of available instances.
+        Does not sweep; the GC thread handles stale collection on its own
+        schedule.
         :param executor: AsyncioExecutor to return.
         """
         with self.lock:
@@ -165,37 +174,48 @@ class AsyncioExecutorPool:
                 self._returned_at[id(executor)] = time.monotonic()
                 self.logger.debug("Returned to pool: AsyncioExecutor %s pool size: %d",
                                   id(executor), len(self.pool_available))
-            # Sweep AFTER recording so any accumulated stale entries get reaped on activity.
-            self._collect_idle_executors()
 
     def shutdown(self) -> None:
         """
-        Drain the GC queue and stop the background GC thread. After this
-        returns, the pool no longer reaps idle executors. Idempotent.
-        Executors still held in pool_used or pool_available are NOT shut
-        down here; callers that want those gone should handle them
-        explicitly.
+        Stop the background GC thread. After this returns, the pool no
+        longer reaps idle executors. Idempotent. Executors still held in
+        pool_used or pool_available are NOT shut down here; callers that
+        want those gone should handle them explicitly.
         """
         if self._gc_thread is None:
             return
-        # Drain the queue - wait for all currently-pending shutdowns to complete.
-        self._gc_queue.join()
-        # Signal the GC thread to exit, then wait for it.
-        self._gc_queue.put(None)
+        self._gc_stop_event.set()
         self._gc_thread.join()
         self._gc_thread = None
 
-    def _collect_idle_executors(self, now: Optional[float] = None) -> None:
+    def _gc_loop(self) -> None:
+        """
+        Active GC loop: sweep, then wait for either the configured
+        interval or the stop event, whichever comes first. Exits cleanly
+        when shutdown() sets the stop event.
+
+        Exceptions from _sweep_once are logged but do not stop the loop,
+        so a single bad executor cannot leak the rest of the pool.
+        """
+        while not self._gc_stop_event.is_set():
+            try:
+                self._sweep_once()
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.warning("GC: sweep raised %s; continuing", exc)
+            # Sleep until the next sweep tick or until shutdown is signaled.
+            self._gc_stop_event.wait(timeout=self.gc_sweep_interval_seconds)
+
+    def _sweep_once(self, now: Optional[float] = None) -> None:
         """
         Identify any executors in pool_available whose idle time exceeds
-        idle_timeout_seconds, remove them from the pool, and enqueue them
-        for shutdown on the background GC thread.
-
-        No-op when not in reuse mode (non-reuse mode shuts executors down
-        on return, so pool_available is always empty in that mode).
+        idle_timeout_seconds, remove them from the pool, and shut them
+        down. No-op when not in reuse mode.
 
         pool_available is FIFO-ordered by return time (oldest at the head),
         so the scan stops at the first non-stale entry.
+
+        Run by the GC thread on its periodic schedule; tests may call it
+        directly with a synthetic `now` for deterministic verification.
 
         :param now: Optional override for the current time, in the same
                     units as time.monotonic(). Intended for tests; production
@@ -220,32 +240,14 @@ class AsyncioExecutorPool:
                 for executor in self.pool_available[:keep_from]:
                     self._returned_at.pop(id(executor), None)
                 del self.pool_available[:keep_from]
-        # Enqueue stale executors for asynchronous shutdown. queue.Queue.put()
-        # is O(1) and non-blocking on an unbounded queue, so the caller pays
-        # only the cost of the list/dict mutations under the lock above.
+        # Shutdown outside the lock to keep the critical section short.
         for executor in to_collect:
-            self._gc_queue.put(executor)
-
-    def _gc_loop(self) -> None:
-        """
-        Background loop draining _gc_queue and shutting down each stale
-        executor. Exits when a None sentinel is dequeued via shutdown().
-        Exceptions are logged but do not stop the loop, so a single bad
-        executor cannot leak the rest.
-        """
-        while True:
-            executor: Optional[AsyncioExecutor] = self._gc_queue.get()
             try:
-                if executor is None:
-                    break
-                try:
-                    self.logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
-                    executor.shutdown(wait=True)
-                except Exception as exc:  # pylint: disable=broad-exception-caught
-                    self.logger.warning(
-                        "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc)
-            finally:
-                self._gc_queue.task_done()
+                self.logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
+                executor.shutdown(wait=True)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.warning(
+                    "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc)
 
     def get_threads_metrics(self) -> Dict[str, Any]:
         """

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -67,7 +67,7 @@ class AsyncioExecutorPool:
     # thread wakes to look for stale executors.
     DEFAULT_GC_SWEEP_INTERVAL_SECONDS: float = 30.0
 
-    def __init__(self, reuse_mode: bool = True,
+    def __init__(self, reuse_mode: bool = True, *,
                  idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS,
                  gc_sweep_interval_seconds: float = DEFAULT_GC_SWEEP_INTERVAL_SECONDS):
         """

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -17,6 +17,7 @@
 """
 See class comments
 """
+from collections.abc import Sequence
 from typing import Any
 from typing import Dict
 from typing import List
@@ -211,9 +212,18 @@ class AsyncioExecutorPool:
             try:
                 self._sweep_once()
             except Exception as exc:  # pylint: disable=broad-exception-caught
-                self.logger.warning("GC: sweep raised %s; continuing", exc)
+                self.logger.warning("GC: sweep raised %s; continuing", exc, exc_info=True)
             # Sleep until the next sweep tick or until shutdown is signaled.
             self._gc_stop_event.wait(timeout=self.gc_sweep_interval_seconds)
+
+    def _collect_executors(self, executors: Sequence[AsyncioExecutor]) -> None:
+        for executor in executors:
+            try:
+                self.logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
+                executor.shutdown(wait=True)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.warning(
+                    "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc)
 
     def _sweep_once(self, now: Optional[float] = None) -> None:
         """
@@ -239,11 +249,20 @@ class AsyncioExecutorPool:
         to_collect: List[AsyncioExecutor] = []
         with self.lock:
             keep_from: int = 0
+            prev_returned_at: float = 0.0
             for executor in self.pool_available:
-                returned_at: float = self._returned_at.get(id(executor), now)
+                if id(executor) not in self._returned_at:
+                    # This should never happen, but log this and record executor
+                    # as returned at the same time as the previous one - to keep sequence invariant still valid.
+                    self.logger.warning(
+                        "GC: executor %s in pool_available but missing return timestamp; fixing",
+                        id(executor))
+                    self._returned_at[id(executor)] = prev_returned_at
+                returned_at: float = self._returned_at.get(id(executor), prev_returned_at)
                 if now - returned_at > self.idle_timeout_seconds:
                     to_collect.append(executor)
                     keep_from += 1
+                    prev_returned_at = returned_at
                 else:
                     break
             if keep_from > 0:
@@ -251,13 +270,7 @@ class AsyncioExecutorPool:
                     self._returned_at.pop(id(executor), None)
                 del self.pool_available[:keep_from]
         # Shutdown outside the lock to keep the critical section short.
-        for executor in to_collect:
-            try:
-                self.logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
-                executor.shutdown(wait=True)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                self.logger.warning(
-                    "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc)
+        self._collect_executors(to_collect)
 
     def get_threads_metrics(self) -> Dict[str, Any]:
         """

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -222,22 +222,22 @@ class AsyncioExecutorPoolGcTest(TestCase):
             gc_sweep_interval_seconds=0.01,    # sweep every 10 ms
         )
 
+        shutdown_called = threading.Event()
         mock_executor = MagicMock()
+
+        def _mark_shutdown(*_args, **_kwargs):
+            shutdown_called.set()
+
+        mock_executor.shutdown.side_effect = _mark_shutdown
         with self.pool.lock:
             self.pool.pool_available = [mock_executor]
             # Backdate the entry so it's stale immediately.
             self.pool._returned_at[id(mock_executor)] = 0.0
 
-        # Wait long enough for the GC thread to tick at least once after we
-        # inserted the entry. 200 ms is generous; the typical case clears
-        # the entry on the next ~10 ms tick.
-        deadline = time.monotonic() + 0.5
-        while time.monotonic() < deadline:
-            with self.pool.lock:
-                is_empty = not self.pool.pool_available
-            if is_empty:
-                break
-            time.sleep(0.01)
+        self.assertTrue(
+            shutdown_called.wait(timeout=0.5),
+            "Expected the active GC thread to call shutdown() on the stale executor on its own.",
+        )
 
         with self.pool.lock:
             remaining = list(self.pool.pool_available)

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -1,0 +1,346 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for AsyncioExecutorPool's idle-executor garbage collection.
+
+The pool keeps a parallel _returned_at timestamp per executor in
+pool_available. A passive sweep (_collect_idle_executors) runs on every
+get_executor() and return_executor() call. The sweep removes any executor
+whose idle time exceeds idle_timeout_seconds and enqueues it on the
+background GC thread for shutdown. Tests drive _collect_idle_executors
+with an explicit `now` to avoid real-time waits, and use _gc_queue.join()
+to wait for the GC thread to finish before asserting on shutdown.
+"""
+import threading
+import time
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
+
+
+class AsyncioExecutorPoolGcTest(TestCase):
+    """
+    Verifies the idle-executor GC policy: stale executors are removed
+    synchronously and shut down asynchronously on the background GC
+    thread; fresh ones are kept; non-reuse mode is unaffected.
+    """
+
+    def tearDown(self):
+        """
+        Stop the background GC thread and shut down any real executors
+        lingering in the pool. Mocks are no-ops.
+        """
+        if getattr(self, "pool", None) is None:
+            return
+        self.pool.shutdown()
+        for executor in list(self.pool.pool_used) + list(self.pool.pool_available):
+            try:
+                executor.shutdown(wait=True)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
+    def test_idle_executor_collected_after_timeout(self):
+        """
+        An executor returned to the pool whose idle time exceeds
+        idle_timeout_seconds is removed from pool_available synchronously
+        and shut down asynchronously by the GC thread.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        mock_executor = MagicMock()
+        self.pool.pool_available = [mock_executor]
+        self.pool._returned_at[id(mock_executor)] = 100.0
+
+        # Simulate 100 seconds elapsed (> 10s threshold).
+        self.pool._collect_idle_executors(now=200.0)
+
+        # Sync side-effects are visible immediately.
+        self.assertEqual(
+            [], self.pool.pool_available,
+            "Expected the stale executor to be removed from pool_available."
+        )
+        self.assertEqual(
+            {}, self.pool._returned_at,
+            "Expected the stale executor's timestamp to be cleared."
+        )
+        # Shutdown happens on the GC thread; wait for it.
+        self.pool._gc_queue.join()
+        mock_executor.shutdown.assert_called_once_with(wait=True)
+
+    def test_fresh_executor_not_collected_within_timeout(self):
+        """
+        An executor whose idle time is below idle_timeout_seconds is left
+        in pool_available, never enqueued for shutdown.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        mock_executor = MagicMock()
+        self.pool.pool_available = [mock_executor]
+        self.pool._returned_at[id(mock_executor)] = 100.0
+
+        # 5 seconds elapsed (< 10s threshold).
+        self.pool._collect_idle_executors(now=105.0)
+        self.pool._gc_queue.join()
+
+        self.assertEqual(
+            [mock_executor], self.pool.pool_available,
+            "Expected the fresh executor to remain in pool_available."
+        )
+        self.assertIn(
+            id(mock_executor), self.pool._returned_at,
+            "Expected the fresh executor's timestamp to remain recorded."
+        )
+        mock_executor.shutdown.assert_not_called()
+
+    def test_gc_preserves_fresh_executors_following_stale_ones(self):
+        """
+        With a mix of stale and fresh executors in pool_available (oldest
+        first), GC removes the stale prefix and stops at the first fresh
+        entry. Fresh executors after a fresh one are also preserved.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        stale_a = MagicMock(name="stale_a")
+        stale_b = MagicMock(name="stale_b")
+        fresh_c = MagicMock(name="fresh_c")
+        fresh_d = MagicMock(name="fresh_d")
+        self.pool.pool_available = [stale_a, stale_b, fresh_c, fresh_d]
+        self.pool._returned_at = {
+            id(stale_a): 100.0,
+            id(stale_b): 101.0,
+            id(fresh_c): 195.0,
+            id(fresh_d): 198.0,
+        }
+
+        # now=200.0: stale_a idle 100s, stale_b idle 99s, fresh_c idle 5s, fresh_d idle 2s.
+        self.pool._collect_idle_executors(now=200.0)
+        self.pool._gc_queue.join()
+
+        self.assertEqual(
+            [fresh_c, fresh_d], self.pool.pool_available,
+            "Expected only the fresh executors to remain, in order."
+        )
+        self.assertEqual(
+            {id(fresh_c): 195.0, id(fresh_d): 198.0}, self.pool._returned_at,
+            "Expected timestamps only for the surviving fresh executors."
+        )
+        stale_a.shutdown.assert_called_once_with(wait=True)
+        stale_b.shutdown.assert_called_once_with(wait=True)
+        fresh_c.shutdown.assert_not_called()
+        fresh_d.shutdown.assert_not_called()
+
+    def test_gc_runs_on_return_executor(self):
+        """
+        Calling return_executor triggers the passive GC sweep. A stale
+        executor sitting in pool_available is collected when another
+        executor is returned.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+
+        stale_executor = MagicMock(name="stale")
+        self.pool.pool_available = [stale_executor]
+        self.pool._returned_at[id(stale_executor)] = -10_000.0
+
+        returning_executor = MagicMock(name="returning")
+        self.pool.pool_used = [returning_executor]
+
+        self.pool.return_executor(returning_executor)
+        self.pool._gc_queue.join()
+
+        self.assertEqual(
+            [returning_executor], self.pool.pool_available,
+            "Expected the stale executor to be GC'd and only the returning one to remain."
+        )
+        stale_executor.shutdown.assert_called_once_with(wait=True)
+
+    def test_gc_runs_on_get_executor(self):
+        """
+        Calling get_executor triggers the passive GC sweep. If the only
+        executor in pool_available is stale, it is collected and
+        get_executor falls through to construct a fresh one.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+
+        stale_executor = MagicMock(name="stale")
+        self.pool.pool_available = [stale_executor]
+        self.pool._returned_at[id(stale_executor)] = -10_000.0
+
+        result = self.pool.get_executor()
+        self.pool._gc_queue.join()
+
+        self.assertIsNot(
+            result, stale_executor,
+            "Expected get_executor to skip the stale entry rather than reuse it."
+        )
+        self.assertNotIn(
+            stale_executor, self.pool.pool_available,
+            "Expected the stale executor to be removed from pool_available."
+        )
+        stale_executor.shutdown.assert_called_once_with(wait=True)
+        # Tidy up the real executor get_executor() just constructed.
+        self.pool.pool_used.remove(result)
+        result.shutdown(wait=True)
+
+    def test_gc_is_noop_in_non_reuse_mode(self):
+        """
+        In reuse_mode=False, _collect_idle_executors is a no-op and no GC
+        thread is started.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=False, idle_timeout_seconds=10.0)
+        mock_executor = MagicMock()
+        self.pool.pool_available = [mock_executor]
+        self.pool._returned_at[id(mock_executor)] = 100.0
+
+        self.pool._collect_idle_executors(now=10_000.0)
+
+        self.assertEqual(
+            [mock_executor], self.pool.pool_available,
+            "Expected non-reuse mode to skip GC entirely; pool_available untouched."
+        )
+        mock_executor.shutdown.assert_not_called()
+        self.assertIsNone(
+            self.pool._gc_thread,
+            "Expected no GC thread to be started in non-reuse mode."
+        )
+
+    def test_default_idle_timeout_is_set(self):
+        """
+        A pool constructed without idle_timeout_seconds picks up the
+        documented class default.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.pool = AsyncioExecutorPool(reuse_mode=True)
+        self.assertEqual(
+            AsyncioExecutorPool.DEFAULT_IDLE_TIMEOUT_SECONDS,
+            self.pool.idle_timeout_seconds,
+            "Expected the default idle timeout to be DEFAULT_IDLE_TIMEOUT_SECONDS."
+        )
+
+    def test_sweep_returns_quickly_even_when_shutdowns_are_slow(self):
+        """
+        The hybrid design moves the expensive shutdown(wait=True) off
+        the caller's path. Even when each per-executor shutdown is
+        deliberately slow, _collect_idle_executors must return in time
+        bounded by the list/dict mutation only -- well under the slow
+        per-shutdown time.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+
+        # Each mock's shutdown will block for 50 ms. With sequential
+        # synchronous shutdown of 5 stale executors, a passive sweep
+        # would take >=250 ms. With the hybrid design, the sweep should
+        # return in single-digit ms.
+        def slow_shutdown(*_args, **_kwargs):
+            time.sleep(0.05)
+
+        stale_executors = [MagicMock(name=f"stale_{i}") for i in range(5)]
+        for executor in stale_executors:
+            executor.shutdown.side_effect = slow_shutdown
+
+        self.pool.pool_available = list(stale_executors)
+        self.pool._returned_at = {id(executor): 0.0 for executor in stale_executors}
+
+        start = time.perf_counter()
+        self.pool._collect_idle_executors(now=1_000.0)
+        sweep_elapsed = time.perf_counter() - start
+
+        # Caller-visible sweep should be much faster than the synchronous
+        # alternative (5 * 50ms = 250ms). 50 ms is a generous bound that
+        # still proves the shutdowns aren't on the caller's thread.
+        self.assertLess(
+            sweep_elapsed, 0.05,
+            f"Sweep should return without waiting on slow shutdowns; "
+            f"actually took {sweep_elapsed*1000:.1f} ms."
+        )
+
+        # Verify the GC thread actually does shut them all down.
+        self.pool._gc_queue.join()
+        for executor in stale_executors:
+            executor.shutdown.assert_called_once_with(wait=True)
+
+    def test_shutdown_stops_gc_thread(self):
+        """
+        pool.shutdown() drains the GC queue and stops the GC thread.
+        After shutdown(), the thread is no longer running.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        gc_thread = self.pool._gc_thread
+        self.assertIsNotNone(gc_thread, "Expected GC thread to be started in reuse mode.")
+        self.assertTrue(gc_thread.is_alive(), "Expected GC thread to be alive after construction.")
+
+        self.pool.shutdown()
+
+        self.assertFalse(gc_thread.is_alive(), "Expected GC thread to exit after shutdown().")
+        self.assertIsNone(self.pool._gc_thread, "Expected _gc_thread to be cleared after shutdown().")
+        # Second shutdown() call is idempotent.
+        self.pool.shutdown()
+
+    def test_gc_thread_survives_shutdown_exception(self):
+        """
+        If one executor's shutdown raises, the GC thread logs and moves on
+        to the next item rather than dying.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+
+        bad_executor = MagicMock(name="bad")
+        bad_executor.shutdown.side_effect = RuntimeError("simulated shutdown failure")
+        good_executor = MagicMock(name="good")
+
+        self.pool.pool_available = [bad_executor, good_executor]
+        self.pool._returned_at = {
+            id(bad_executor): 0.0,
+            id(good_executor): 0.0,
+        }
+
+        self.pool._collect_idle_executors(now=1_000.0)
+        self.pool._gc_queue.join()
+
+        bad_executor.shutdown.assert_called_once_with(wait=True)
+        good_executor.shutdown.assert_called_once_with(wait=True)
+        # GC thread must still be alive after handling the exception.
+        self.assertTrue(
+            self.pool._gc_thread.is_alive(),
+            "Expected GC thread to survive a per-executor shutdown exception."
+        )
+
+    def test_no_extra_gc_threads_leak_across_pools(self):
+        """
+        Each pool starts exactly one GC thread; shutdown() reliably stops
+        it. Constructing and shutting down many pools must not leak
+        threads.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        pools = [AsyncioExecutorPool(reuse_mode=True) for _ in range(5)]
+        for pool in pools:
+            pool.shutdown()
+        # The current TestCase's pool is None; tearDown is a no-op.
+        live_gc_threads = [
+            t for t in threading.enumerate()
+            if t.name.startswith("AsyncioExecutorPool-GC-") and t.is_alive()
+        ]
+        self.assertEqual(
+            [], live_gc_threads,
+            f"Expected no GC threads to remain after shutdown(); found {live_gc_threads}."
+        )

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -15,15 +15,15 @@
 #
 # END COPYRIGHT
 """
-Unit tests for AsyncioExecutorPool's idle-executor garbage collection.
+Unit tests for AsyncioExecutorPool's active idle-executor garbage
+collection.
 
-The pool keeps a parallel _returned_at timestamp per executor in
-pool_available. A passive sweep (_collect_idle_executors) runs on every
-get_executor() and return_executor() call. The sweep removes any executor
-whose idle time exceeds idle_timeout_seconds and enqueues it on the
-background GC thread for shutdown. Tests drive _collect_idle_executors
-with an explicit `now` to avoid real-time waits, and use _gc_queue.join()
-to wait for the GC thread to finish before asserting on shutdown.
+The GC runs on a dedicated daemon thread which periodically calls
+_sweep_once(): identify executors in pool_available whose idle period
+exceeds idle_timeout_seconds, remove them, and shut them down. Most
+tests drive _sweep_once() directly with a synthetic `now` to verify
+behavior deterministically without waiting on real time; one end-to-end
+test exercises the periodic thread with a tight sweep interval.
 """
 import threading
 import time
@@ -36,9 +36,10 @@ from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
 
 class AsyncioExecutorPoolGcTest(TestCase):
     """
-    Verifies the idle-executor GC policy: stale executors are removed
-    synchronously and shut down asynchronously on the background GC
-    thread; fresh ones are kept; non-reuse mode is unaffected.
+    Verifies the active idle-executor GC: the sweep correctly partitions
+    stale vs fresh executors, the periodic GC thread runs sweeps on its
+    own schedule, and the lifecycle (start / shutdown / exception safety)
+    is robust.
     """
 
     def tearDown(self):
@@ -55,11 +56,10 @@ class AsyncioExecutorPoolGcTest(TestCase):
             except Exception:  # pylint: disable=broad-exception-caught
                 pass
 
-    def test_idle_executor_collected_after_timeout(self):
+    def test_sweep_collects_idle_executor_after_timeout(self):
         """
-        An executor returned to the pool whose idle time exceeds
-        idle_timeout_seconds is removed from pool_available synchronously
-        and shut down asynchronously by the GC thread.
+        _sweep_once() removes and shuts down an executor whose idle period
+        exceeds idle_timeout_seconds.
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
@@ -68,9 +68,8 @@ class AsyncioExecutorPoolGcTest(TestCase):
         self.pool._returned_at[id(mock_executor)] = 100.0
 
         # Simulate 100 seconds elapsed (> 10s threshold).
-        self.pool._collect_idle_executors(now=200.0)
+        self.pool._sweep_once(now=200.0)
 
-        # Sync side-effects are visible immediately.
         self.assertEqual(
             [], self.pool.pool_available,
             "Expected the stale executor to be removed from pool_available."
@@ -79,14 +78,12 @@ class AsyncioExecutorPoolGcTest(TestCase):
             {}, self.pool._returned_at,
             "Expected the stale executor's timestamp to be cleared."
         )
-        # Shutdown happens on the GC thread; wait for it.
-        self.pool._gc_queue.join()
         mock_executor.shutdown.assert_called_once_with(wait=True)
 
-    def test_fresh_executor_not_collected_within_timeout(self):
+    def test_sweep_preserves_fresh_executor_within_timeout(self):
         """
         An executor whose idle time is below idle_timeout_seconds is left
-        in pool_available, never enqueued for shutdown.
+        in pool_available and not shut down.
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
@@ -95,8 +92,7 @@ class AsyncioExecutorPoolGcTest(TestCase):
         self.pool._returned_at[id(mock_executor)] = 100.0
 
         # 5 seconds elapsed (< 10s threshold).
-        self.pool._collect_idle_executors(now=105.0)
-        self.pool._gc_queue.join()
+        self.pool._sweep_once(now=105.0)
 
         self.assertEqual(
             [mock_executor], self.pool.pool_available,
@@ -108,11 +104,11 @@ class AsyncioExecutorPoolGcTest(TestCase):
         )
         mock_executor.shutdown.assert_not_called()
 
-    def test_gc_preserves_fresh_executors_following_stale_ones(self):
+    def test_sweep_preserves_fresh_executors_following_stale_ones(self):
         """
         With a mix of stale and fresh executors in pool_available (oldest
-        first), GC removes the stale prefix and stops at the first fresh
-        entry. Fresh executors after a fresh one are also preserved.
+        first), the sweep removes the stale prefix and stops at the first
+        fresh entry. Fresh executors after a fresh one are also preserved.
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
@@ -129,8 +125,7 @@ class AsyncioExecutorPoolGcTest(TestCase):
         }
 
         # now=200.0: stale_a idle 100s, stale_b idle 99s, fresh_c idle 5s, fresh_d idle 2s.
-        self.pool._collect_idle_executors(now=200.0)
-        self.pool._gc_queue.join()
+        self.pool._sweep_once(now=200.0)
 
         self.assertEqual(
             [fresh_c, fresh_d], self.pool.pool_available,
@@ -145,64 +140,10 @@ class AsyncioExecutorPoolGcTest(TestCase):
         fresh_c.shutdown.assert_not_called()
         fresh_d.shutdown.assert_not_called()
 
-    def test_gc_runs_on_return_executor(self):
+    def test_sweep_is_noop_in_non_reuse_mode(self):
         """
-        Calling return_executor triggers the passive GC sweep. A stale
-        executor sitting in pool_available is collected when another
-        executor is returned.
-        """
-        # pylint: disable=attribute-defined-outside-init,protected-access
-        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
-
-        stale_executor = MagicMock(name="stale")
-        self.pool.pool_available = [stale_executor]
-        self.pool._returned_at[id(stale_executor)] = -10_000.0
-
-        returning_executor = MagicMock(name="returning")
-        self.pool.pool_used = [returning_executor]
-
-        self.pool.return_executor(returning_executor)
-        self.pool._gc_queue.join()
-
-        self.assertEqual(
-            [returning_executor], self.pool.pool_available,
-            "Expected the stale executor to be GC'd and only the returning one to remain."
-        )
-        stale_executor.shutdown.assert_called_once_with(wait=True)
-
-    def test_gc_runs_on_get_executor(self):
-        """
-        Calling get_executor triggers the passive GC sweep. If the only
-        executor in pool_available is stale, it is collected and
-        get_executor falls through to construct a fresh one.
-        """
-        # pylint: disable=attribute-defined-outside-init,protected-access
-        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
-
-        stale_executor = MagicMock(name="stale")
-        self.pool.pool_available = [stale_executor]
-        self.pool._returned_at[id(stale_executor)] = -10_000.0
-
-        result = self.pool.get_executor()
-        self.pool._gc_queue.join()
-
-        self.assertIsNot(
-            result, stale_executor,
-            "Expected get_executor to skip the stale entry rather than reuse it."
-        )
-        self.assertNotIn(
-            stale_executor, self.pool.pool_available,
-            "Expected the stale executor to be removed from pool_available."
-        )
-        stale_executor.shutdown.assert_called_once_with(wait=True)
-        # Tidy up the real executor get_executor() just constructed.
-        self.pool.pool_used.remove(result)
-        result.shutdown(wait=True)
-
-    def test_gc_is_noop_in_non_reuse_mode(self):
-        """
-        In reuse_mode=False, _collect_idle_executors is a no-op and no GC
-        thread is started.
+        In reuse_mode=False, _sweep_once() is a no-op and no GC thread is
+        started.
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=False, idle_timeout_seconds=10.0)
@@ -210,7 +151,7 @@ class AsyncioExecutorPoolGcTest(TestCase):
         self.pool.pool_available = [mock_executor]
         self.pool._returned_at[id(mock_executor)] = 100.0
 
-        self.pool._collect_idle_executors(now=10_000.0)
+        self.pool._sweep_once(now=10_000.0)
 
         self.assertEqual(
             [mock_executor], self.pool.pool_available,
@@ -222,10 +163,84 @@ class AsyncioExecutorPoolGcTest(TestCase):
             "Expected no GC thread to be started in non-reuse mode."
         )
 
-    def test_default_idle_timeout_is_set(self):
+    def test_get_and_return_do_not_sweep(self):
         """
-        A pool constructed without idle_timeout_seconds picks up the
-        documented class default.
+        get_executor() and return_executor() must not perform a sweep -
+        sweeping is the GC thread's exclusive responsibility. A stale
+        executor sitting in pool_available is not shut down by caller-side
+        calls.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        # Long sweep interval so the GC thread doesn't race the assertions.
+        self.pool = AsyncioExecutorPool(
+            reuse_mode=True,
+            idle_timeout_seconds=10.0,
+            gc_sweep_interval_seconds=3600.0,
+        )
+
+        stale_executor = MagicMock(name="stale")
+        self.pool.pool_available = [stale_executor]
+        self.pool._returned_at[id(stale_executor)] = -10_000.0
+
+        # Put a different executor through the get/return cycle.
+        returning = MagicMock(name="returning")
+        self.pool.pool_used = [returning]
+        self.pool.return_executor(returning)
+
+        # The stale executor is still there: no caller-side sweep.
+        self.assertIn(
+            stale_executor, self.pool.pool_available,
+            "Expected return_executor() not to sweep the stale executor."
+        )
+        stale_executor.shutdown.assert_not_called()
+
+        # get_executor() can reuse a stale entry, but still does not shut it down.
+        # FIFO order: stale_executor was added first, so it's at the head.
+        result = self.pool.get_executor()
+        self.assertIs(
+            result, stale_executor,
+            "Expected get_executor() to reuse the head entry without sweeping."
+        )
+        stale_executor.shutdown.assert_not_called()
+
+    def test_active_gc_thread_collects_idle_executor_on_its_own_schedule(self):
+        """
+        With no get_executor() / return_executor() activity, the GC thread
+        still wakes on its interval and collects stale executors.
+        """
+        # pylint: disable=attribute-defined-outside-init,protected-access
+        # Tight schedule: any stale executor is collected within tens of ms.
+        self.pool = AsyncioExecutorPool(
+            reuse_mode=True,
+            idle_timeout_seconds=0.001,        # 1 ms -> any backdated entry is stale
+            gc_sweep_interval_seconds=0.01,    # sweep every 10 ms
+        )
+
+        mock_executor = MagicMock()
+        with self.pool.lock:
+            self.pool.pool_available = [mock_executor]
+            # Backdate the entry so it's stale immediately.
+            self.pool._returned_at[id(mock_executor)] = 0.0
+
+        # Wait long enough for the GC thread to tick at least once after we
+        # inserted the entry. 200 ms is generous; the typical case clears
+        # the entry on the next ~10 ms tick.
+        deadline = time.monotonic() + 0.5
+        while time.monotonic() < deadline:
+            if not self.pool.pool_available:
+                break
+            time.sleep(0.01)
+
+        self.assertEqual(
+            [], self.pool.pool_available,
+            "Expected the active GC thread to collect the stale executor on its own."
+        )
+        mock_executor.shutdown.assert_called_once_with(wait=True)
+
+    def test_default_config_values_are_set(self):
+        """
+        A pool constructed without overrides picks up the documented
+        class-level defaults for both idle timeout and sweep interval.
         """
         # pylint: disable=attribute-defined-outside-init
         self.pool = AsyncioExecutorPool(reuse_mode=True)
@@ -234,57 +249,23 @@ class AsyncioExecutorPoolGcTest(TestCase):
             self.pool.idle_timeout_seconds,
             "Expected the default idle timeout to be DEFAULT_IDLE_TIMEOUT_SECONDS."
         )
-
-    def test_sweep_returns_quickly_even_when_shutdowns_are_slow(self):
-        """
-        The hybrid design moves the expensive shutdown(wait=True) off
-        the caller's path. Even when each per-executor shutdown is
-        deliberately slow, _collect_idle_executors must return in time
-        bounded by the list/dict mutation only -- well under the slow
-        per-shutdown time.
-        """
-        # pylint: disable=attribute-defined-outside-init,protected-access
-        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
-
-        # Each mock's shutdown will block for 50 ms. With sequential
-        # synchronous shutdown of 5 stale executors, a passive sweep
-        # would take >=250 ms. With the hybrid design, the sweep should
-        # return in single-digit ms.
-        def slow_shutdown(*_args, **_kwargs):
-            time.sleep(0.05)
-
-        stale_executors = [MagicMock(name=f"stale_{i}") for i in range(5)]
-        for executor in stale_executors:
-            executor.shutdown.side_effect = slow_shutdown
-
-        self.pool.pool_available = list(stale_executors)
-        self.pool._returned_at = {id(executor): 0.0 for executor in stale_executors}
-
-        start = time.perf_counter()
-        self.pool._collect_idle_executors(now=1_000.0)
-        sweep_elapsed = time.perf_counter() - start
-
-        # Caller-visible sweep should be much faster than the synchronous
-        # alternative (5 * 50ms = 250ms). 50 ms is a generous bound that
-        # still proves the shutdowns aren't on the caller's thread.
-        self.assertLess(
-            sweep_elapsed, 0.05,
-            f"Sweep should return without waiting on slow shutdowns; "
-            f"actually took {sweep_elapsed*1000:.1f} ms."
+        self.assertEqual(
+            AsyncioExecutorPool.DEFAULT_GC_SWEEP_INTERVAL_SECONDS,
+            self.pool.gc_sweep_interval_seconds,
+            "Expected the default sweep interval to be DEFAULT_GC_SWEEP_INTERVAL_SECONDS."
         )
-
-        # Verify the GC thread actually does shut them all down.
-        self.pool._gc_queue.join()
-        for executor in stale_executors:
-            executor.shutdown.assert_called_once_with(wait=True)
 
     def test_shutdown_stops_gc_thread(self):
         """
-        pool.shutdown() drains the GC queue and stops the GC thread.
-        After shutdown(), the thread is no longer running.
+        pool.shutdown() signals the stop event and joins the GC thread.
+        After shutdown(), the thread is not alive.
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
-        self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        # Long sweep interval to make sure shutdown actually interrupts the wait.
+        self.pool = AsyncioExecutorPool(
+            reuse_mode=True,
+            gc_sweep_interval_seconds=3600.0,
+        )
         gc_thread = self.pool._gc_thread
         self.assertIsNotNone(gc_thread, "Expected GC thread to be started in reuse mode.")
         self.assertTrue(gc_thread.is_alive(), "Expected GC thread to be alive after construction.")
@@ -296,10 +277,11 @@ class AsyncioExecutorPoolGcTest(TestCase):
         # Second shutdown() call is idempotent.
         self.pool.shutdown()
 
-    def test_gc_thread_survives_shutdown_exception(self):
+    def test_gc_thread_survives_sweep_exception(self):
         """
-        If one executor's shutdown raises, the GC thread logs and moves on
-        to the next item rather than dying.
+        If a per-executor shutdown raises during sweep, the GC thread
+        logs and continues; subsequent stale executors are still
+        collected on the same sweep.
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
@@ -314,28 +296,26 @@ class AsyncioExecutorPoolGcTest(TestCase):
             id(good_executor): 0.0,
         }
 
-        self.pool._collect_idle_executors(now=1_000.0)
-        self.pool._gc_queue.join()
+        # Drive sweep synchronously on the test thread.
+        self.pool._sweep_once(now=1_000.0)
 
         bad_executor.shutdown.assert_called_once_with(wait=True)
         good_executor.shutdown.assert_called_once_with(wait=True)
-        # GC thread must still be alive after handling the exception.
+        self.assertEqual([], self.pool.pool_available)
         self.assertTrue(
             self.pool._gc_thread.is_alive(),
-            "Expected GC thread to survive a per-executor shutdown exception."
+            "Expected the GC thread itself to remain alive."
         )
 
-    def test_no_extra_gc_threads_leak_across_pools(self):
+    def test_no_gc_threads_leak_across_pools(self):
         """
         Each pool starts exactly one GC thread; shutdown() reliably stops
         it. Constructing and shutting down many pools must not leak
         threads.
         """
-        # pylint: disable=attribute-defined-outside-init
         pools = [AsyncioExecutorPool(reuse_mode=True) for _ in range(5)]
         for pool in pools:
             pool.shutdown()
-        # The current TestCase's pool is None; tearDown is a no-op.
         live_gc_threads = [
             t for t in threading.enumerate()
             if t.name.startswith("AsyncioExecutorPool-GC-") and t.is_alive()

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -180,13 +180,13 @@ class AsyncioExecutorPoolGcTest(TestCase):
             idle_timeout_seconds=10.0,
             gc_sweep_interval_seconds=3600.0,
         )
+        # Stop the GC thread before mutating internal state to avoid racing the initial sweep.
+        self.pool.shutdown()
 
         stale_executor = MagicMock(name="stale")
-        self.pool.pool_available = [stale_executor]
-        self.pool._returned_at[id(stale_executor)] = -10_000.0
-
-        # Stop the GC thread so it doesn't interfere with the test
-        self.pool.shutdown()
+        with self.pool.lock:
+            self.pool.pool_available = [stale_executor]
+            self.pool._returned_at[id(stale_executor)] = -10_000.0
 
         # Put a different executor through the get/return cycle.
         returning = MagicMock(name="returning")

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -233,12 +233,16 @@ class AsyncioExecutorPoolGcTest(TestCase):
         # the entry on the next ~10 ms tick.
         deadline = time.monotonic() + 0.5
         while time.monotonic() < deadline:
-            if not self.pool.pool_available:
+            with self.pool.lock:
+                is_empty = not self.pool.pool_available
+            if is_empty:
                 break
             time.sleep(0.01)
 
+        with self.pool.lock:
+            remaining = list(self.pool.pool_available)
         self.assertEqual(
-            [], self.pool.pool_available,
+            [], remaining,
             "Expected the active GC thread to collect the stale executor on its own."
         )
         mock_executor.shutdown.assert_called_once_with(wait=True)

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -185,6 +185,9 @@ class AsyncioExecutorPoolGcTest(TestCase):
         self.pool.pool_available = [stale_executor]
         self.pool._returned_at[id(stale_executor)] = -10_000.0
 
+        # Stop the GC thread so it doesn't interfere with the test
+        self.pool.shutdown()
+
         # Put a different executor through the get/return cycle.
         returning = MagicMock(name="returning")
         self.pool.pool_used = [returning]

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -293,14 +293,16 @@ class AsyncioExecutorPoolGcTest(TestCase):
         bad_executor.shutdown.side_effect = RuntimeError("simulated shutdown failure")
         good_executor = MagicMock(name="good")
 
-        self.pool.pool_available = [bad_executor, good_executor]
-        self.pool._returned_at = {
-            id(bad_executor): 0.0,
-            id(good_executor): 0.0,
-        }
+        base = time.monotonic()
+        with self.pool.lock:
+            self.pool.pool_available = [bad_executor, good_executor]
+            self.pool._returned_at = {
+                id(bad_executor): base,
+                id(good_executor): base,
+            }
 
-        # Drive sweep synchronously on the test thread.
-        self.pool._sweep_once(now=1_000.0)
+        # Drive sweep synchronously on the test thread with a synthetic time.
+        self.pool._sweep_once(now=base + self.pool.idle_timeout_seconds + 1.0)
 
         bad_executor.shutdown.assert_called_once_with(wait=True)
         good_executor.shutdown.assert_called_once_with(wait=True)

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -114,6 +114,7 @@ class AsyncioExecutorPoolGcTest(TestCase):
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        self.pool.shutdown()  # stop background GC; this test drives _sweep_once() manually
         stale_a = MagicMock(name="stale_a")
         stale_b = MagicMock(name="stale_b")
         fresh_c = MagicMock(name="fresh_c")

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -63,6 +63,7 @@ class AsyncioExecutorPoolGcTest(TestCase):
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        self.pool.shutdown()  # stop background GC; this test drives _sweep_once() manually
         mock_executor = MagicMock()
         self.pool.pool_available = [mock_executor]
         self.pool._returned_at[id(mock_executor)] = 100.0

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -88,6 +88,7 @@ class AsyncioExecutorPoolGcTest(TestCase):
         """
         # pylint: disable=attribute-defined-outside-init,protected-access
         self.pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=10.0)
+        self.pool.shutdown()  # stop background GC; this test drives _sweep_once() manually
         mock_executor = MagicMock()
         self.pool.pool_available = [mock_executor]
         self.pool._returned_at[id(mock_executor)] = 100.0

--- a/tests/asyncio/asyncio_executor_pool_gc_test.py
+++ b/tests/asyncio/asyncio_executor_pool_gc_test.py
@@ -313,14 +313,18 @@ class AsyncioExecutorPoolGcTest(TestCase):
         it. Constructing and shutting down many pools must not leak
         threads.
         """
+        baseline_gc_threads = {
+            t.name for t in threading.enumerate()
+            if t.name.startswith("AsyncioExecutorPool-GC-") and t.is_alive()
+        }
         pools = [AsyncioExecutorPool(reuse_mode=True) for _ in range(5)]
         for pool in pools:
             pool.shutdown()
         live_gc_threads = [
             t for t in threading.enumerate()
-            if t.name.startswith("AsyncioExecutorPool-GC-") and t.is_alive()
+            if t.name.startswith("AsyncioExecutorPool-GC-") and t.is_alive() and t.name not in baseline_gc_threads
         ]
         self.assertEqual(
             [], live_gc_threads,
-            f"Expected no GC threads to remain after shutdown(); found {live_gc_threads}."
+            f"Expected no new GC threads to remain after shutdown(); found {live_gc_threads}."
         )


### PR DESCRIPTION
This PR implements garbage collector for AsyncioExecutor instances that are idle (not used by client requests in flight) for configurable amount of time.
This allows us to manage service memory footprint, because each AsyncioExecutor consumes non-trivial amount of memory - main thread + event loop + thread pool owned by event loop.
Unit tests are added, tested manually with some neuro-san runs.
