### PR TITLE
Add Checkmarx One workflow via build-common 1.0.8

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -19,6 +19,7 @@ jobs:
       base-uri: ${{ vars.CX_BASE_URI }}
       cx-tenant: ${{ vars.CX_TENANT }}
       cx-client-id: ${{ vars.CX_CLIENT_ID }}
+      scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=1;sast-high=1"'
     secrets:
       CX_CLIENT_SECRET: ${{ secrets.CX_CLIENT_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -2,7 +2,6 @@
 name: Checkmarx One
 
 on:
-  push:
   schedule:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,0 +1,26 @@
+---
+name: Checkmarx One
+
+on:
+  schedule:
+    # M-F at 2 am UTC
+    - cron: '0 2 * * 1-5'
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  checkmarx:
+    # 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@30321843331e00848309b34e08b839e1f6490ba2
+    with:
+      base-uri: ${{ vars.CX_BASE_URI }}
+      cx-tenant: ${{ vars.CX_TENANT }}
+      cx-client-id: ${{ vars.CX_CLIENT_ID }}
+    secrets:
+      CX_CLIENT_SECRET: ${{ secrets.CX_CLIENT_SECRET }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    permissions:
+      contents: write
+      security-events: write

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -2,6 +2,7 @@
 name: Checkmarx One
 
 on:
+  push:
   schedule:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'


### PR DESCRIPTION
## Summary

Adds a Checkmarx One SAST scan workflow that calls the new `_checkmarx.yml` reusable workflow from build-common 1.0.8.

Triggers: scheduled (M-F 2 am UTC), manual dispatch, and release publish. On release, the scan report PDF is automatically attached to the GitHub release.

Requires `CX_BASE_URI`, `CX_TENANT`, `CX_CLIENT_ID` repo variables and `CX_CLIENT_SECRET`, `SLACK_WEBHOOK_URL` secrets to be configured.

Link to Devin session: https://app.devin.ai/sessions/176e609f22674275aaef17ddb4772e66
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/leaf-common/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->