### PR TITLE
SensitiveLogger class

### DIFF
--- a/leaf_common/asyncio/asyncio_executor.py
+++ b/leaf_common/asyncio/asyncio_executor.py
@@ -39,6 +39,7 @@ from concurrent import futures
 from leaf_common.asyncio.event_loop_factory import EventLoopFactory
 from leaf_common.asyncio.task_executor import TaskExecutor
 from leaf_common.asyncio.asyncio_threadpool_executor import AsyncioThreadPoolExecutor
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 EXECUTOR_START_TIMEOUT_SECONDS: int = 5
 
@@ -444,7 +445,8 @@ class AsyncioExecutor(TaskExecutor):
             for line in formatted_exception:
                 if line.endswith("\n"):
                     line = line[:-1]
-                self.logger.info("%s", line)
+                sensitive_logger = SensitiveLogger(self.logger)
+                sensitive_logger.info("%s", line)
 
         # As a last gesture, remove the background task from the map
         # we use to keep its reference around. Do it safely:

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -29,6 +29,7 @@ import threading
 import time
 
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 
 class AsyncioExecutorPool:
@@ -214,14 +215,16 @@ class AsyncioExecutorPool:
             try:
                 self._sweep_once()
             except Exception as exc:  # pylint: disable=broad-exception-caught
-                self.logger.warning("GC: sweep raised %s; continuing", exc, exc_info=True)
+                sensitive_logger = SensitiveLogger(self.logger)
+                sensitive_logger.warning("GC: sweep raised %s; continuing", exc, exc_info=True)
             # Sleep until the next sweep tick or until shutdown is signaled.
             self._gc_stop_event.wait(timeout=self.gc_sweep_interval_seconds)
 
     def _collect_executors(self, executors: Sequence[AsyncioExecutor]) -> None:
         for executor in executors:
             try:
-                self.logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
+                sensitive_logger = SensitiveLogger(self.logger)
+                sensitive_logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
                 executor.shutdown(wait=True)
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 self.logger.warning(

--- a/leaf_common/logging/sensitive_logger.py
+++ b/leaf_common/logging/sensitive_logger.py
@@ -22,7 +22,7 @@ from logging import Logger
 from os import getenv
 
 
-class SensitiveLogger(Logger):
+class SensitiveLogger:
     """
     Wraps a logger to mask sensitive information.
     Uses the same general Logger interface as the whole world already uses.
@@ -39,7 +39,6 @@ class SensitiveLogger(Logger):
 
         :param logger: The wrapped logger to redirect write() calls to.
         """
-        super().__init__(logger.name)
         self.logger: Logger = logger
         self._should_log: bool = getenv('LEAF_LOG_SENSITIVE', 'true').lower() == 'true'
 

--- a/leaf_common/logging/sensitive_logger.py
+++ b/leaf_common/logging/sensitive_logger.py
@@ -1,0 +1,144 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+
+from logging import Logger
+from os import getenv
+
+
+class SensitiveLogger(Logger):
+    """
+    Wraps a logger to mask sensitive information.
+    Uses the same general Logger interface as the whole world already uses.
+
+    We assume that any information coming in to this logger is considered sensitive information.
+    Turning off senstive logging information can be done by setting the LEAF_LOG_SENSTIVE to "false".
+    By default this is turned on, allowing developers to see sensitive information.
+    Strongly consider turning this off for production deployments.
+    """
+
+    def __init__(self, logger: Logger):
+        """
+        Constructor.
+
+        :param logger: The wrapped logger to redirect write() calls to.
+        """
+        super().__init__(logger.name)
+        self.logger: Logger = logger
+        self._should_log: bool = getenv('LEAF_LOG_SENSITIVE', 'true').lower() == 'true'
+
+    def should_log(self) -> bool:
+        """
+        :return: True if this logger should log
+        """
+        return self._should_log
+
+    def debug(self, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'DEBUG'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug("Houston, we have a %s", "thorny problem", exc_info=True)
+        """
+        if not self.should_log():
+            return
+        self.logger.debug(msg, *args, **kwargs)
+
+    def info(self, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'INFO'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.info("Houston, we have a %s", "notable problem", exc_info=True)
+        """
+        if not self.should_log():
+            return
+        self.logger.info(msg, *args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'WARNING'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.warning("Houston, we have a %s", "bit of a problem", exc_info=True)
+        """
+        if not self.should_log():
+            return
+        self.logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'ERROR'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.error("Houston, we have a %s", "major problem", exc_info=True)
+        """
+        if not self.should_log():
+            return
+        self.logger.error(msg, *args, **kwargs)
+
+    def exception(self, msg, *args, exc_info=True, **kwargs):
+        """
+        Convenience method for logging an ERROR with exception information.
+        """
+        if not self.should_log():
+            return
+        self.logger.exception(msg, *args, exc_info=exc_info, **kwargs)
+
+    def critical(self, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'CRITICAL'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.critical("Houston, we have a %s", "major disaster", exc_info=True)
+        """
+        if not self.should_log():
+            return
+        self.logger.critical(msg, *args, **kwargs)
+
+    def fatal(self, msg, *args, **kwargs):
+        """
+        Don't use this method, use critical() instead.
+        """
+        if not self.should_log():
+            return
+        self.logger.fatal(msg, *args, **kwargs)
+
+    def log(self, level, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with the integer severity 'level'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.log(level, "We have a %s", "mysterious problem", exc_info=True)
+        """
+        if not self.should_log():
+            return
+        self.logger.log(level, msg, *args, **kwargs)

--- a/leaf_common/persistence/mechanism/local_file_persistence_mechanism.py
+++ b/leaf_common/persistence/mechanism/local_file_persistence_mechanism.py
@@ -66,6 +66,9 @@ class LocalFilePersistenceMechanism(AbstractPersistenceMechanism):
             if self.must_exist():
                 raise ex
 
+        # CheckMarx false-positive.  This is flagged as an Improper Resource Shutdown or Release
+        # This is simply how the contract works with these classes.
+        # We return a fileobj so a higher-level abstract API can close it.
         return fileobj
 
     def open_dest_for_write(self, send_from_fileobj,

--- a/leaf_common/persistence/mechanism/s3_file_persistence_mechanism.py
+++ b/leaf_common/persistence/mechanism/s3_file_persistence_mechanism.py
@@ -20,6 +20,7 @@ See class comment for details.
 import logging
 import os
 
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.persistence.mechanism.abstract_persistence_mechanism \
     import AbstractPersistenceMechanism
 
@@ -103,10 +104,11 @@ class S3FilePersistenceMechanism(AbstractPersistenceMechanism):
                 return_fileobj = None
             else:
                 # Something else has gone wrong
-                logger.error("S3 file read %s %s some other error happened %s",
-                             str(self.bucket_base),
-                             str(key),
-                             str(exception.response['Error']['Code']))
+                sensitive_logger = SensitiveLogger(logger)
+                sensitive_logger.error("S3 file read %s %s some other error happened %s",
+                                       str(self.bucket_base),
+                                       str(key),
+                                       str(exception.response['Error']['Code']))
                 raise
 
         return return_fileobj

--- a/leaf_common/session/grpc_channel_security.py
+++ b/leaf_common/session/grpc_channel_security.py
@@ -33,6 +33,7 @@ from grpc import composite_call_credentials
 from grpc import composite_channel_credentials
 from grpc import ssl_channel_credentials
 
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.time.timeout import Timeout
 from leaf_common.security.service.service_accessor_factory \
     import ServiceAccessorFactory
@@ -206,9 +207,10 @@ class GrpcChannelSecurity():
         except Exception as err:
             frameinfo = getframeinfo(currentframe())
             logger = logging.getLogger(__name__)
-            logger.warning("%s %s %s", str(err),
-                           str(frameinfo.filename),
-                           str(frameinfo.lineno))
+            sensitive_logger = SensitiveLogger(logger)
+            sensitive_logger.warning("%s %s %s", str(err),
+                                     str(frameinfo.filename),
+                                     str(frameinfo.lineno))
             raise err
 
         # Any one of the certs provided can be None.

--- a/leaf_common/session/grpc_client_retry.py
+++ b/leaf_common/session/grpc_client_retry.py
@@ -32,10 +32,10 @@ from grpc import channel_ready_future
 from grpc import insecure_channel
 from grpc import secure_channel
 
-from leaf_common.time.timeout import Timeout
-
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.session.grpc_channel_security import GrpcChannelSecurity
 from leaf_common.session.grpc_metadata_util import GrpcMetadataUtil
+from leaf_common.time.timeout import Timeout
 
 
 class GrpcClientRetry():
@@ -272,7 +272,8 @@ class GrpcClientRetry():
                 if self.debug:
                     self.logger.error(exception)
                     error = traceback.format_exc()
-                    self.logger.error(error)
+                    sensitive_logger = SensitiveLogger(self.logger)
+                    sensitive_logger.error(error)
 
                 log_exception = True
                 exception_str = str(exception)
@@ -331,8 +332,9 @@ class GrpcClientRetry():
                     # Log the problem and wait to try again.
                     info = "Info: Exception when calling %s: %s. " + \
                             "Retrying in %s secs."
-                    self.logger.warning(info, str(method_name), exception_str,
-                                        str(self.poll_interval_seconds))
+                    sensitive_logger = SensitiveLogger(self.logger)
+                    sensitive_logger.warning(info, str(method_name), exception_str,
+                                             str(self.poll_interval_seconds))
 
                 # Close the channel before sleep to tidy up sooner
                 # We do not necessarily want a new token just

--- a/leaf_common/session/grpc_client_retry.py
+++ b/leaf_common/session/grpc_client_retry.py
@@ -195,7 +195,7 @@ class GrpcClientRetry():
 
         return stub_instance
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-locals
     def must_have_response(self, method_name, rpc_call_from_stub, *args):   # noqa: C901
         """
         Keeps trying to connect to the gRPC service to make a single


### PR DESCRIPTION
* Create a SensitiveLogger class which wraps an existing logging.Logger class.
* This class has a similar interface as the logging.Logger class, but does not derive from it.
* Any information that comes to this logger is assumed to be sensitive.
* Control of sensitive log information can be made by setting a single environment variable LEAF_LOG_SENSITIVE to false
* The default is true to allow for a default development situation.

Then, use the SenstiveLogger to funnel CheckMarx logging complaints to instances of it,
so we can have the env var be the final spigot on whether this information goes out into the world or not.
People who want a total lockdown of a production system can do that.

There will probably still be CheckMarx complaints about these, but we can handle the justification comment at the new destination(s) within SensitiveLogger.