### PR TITLE
More sensitive logs

### DIFF
--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -221,13 +221,13 @@ class AsyncioExecutorPool:
             self._gc_stop_event.wait(timeout=self.gc_sweep_interval_seconds)
 
     def _collect_executors(self, executors: Sequence[AsyncioExecutor]) -> None:
+            sensitive_logger = SensitiveLogger(self.logger)
         for executor in executors:
             try:
-                sensitive_logger = SensitiveLogger(self.logger)
                 sensitive_logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))
                 executor.shutdown(wait=True)
             except Exception as exc:  # pylint: disable=broad-exception-caught
-                self.logger.warning(
+                sensitive_logger.warning(
                     "GC: shutdown failed for AsyncioExecutor %s: %s", id(executor), exc, exc_info=True)
 
     def _sweep_once(self, now: Optional[float] = None) -> None:

--- a/leaf_common/asyncio/asyncio_executor_pool.py
+++ b/leaf_common/asyncio/asyncio_executor_pool.py
@@ -221,7 +221,7 @@ class AsyncioExecutorPool:
             self._gc_stop_event.wait(timeout=self.gc_sweep_interval_seconds)
 
     def _collect_executors(self, executors: Sequence[AsyncioExecutor]) -> None:
-            sensitive_logger = SensitiveLogger(self.logger)
+        sensitive_logger = SensitiveLogger(self.logger)
         for executor in executors:
             try:
                 sensitive_logger.debug("GC: shutting down idle AsyncioExecutor %s", id(executor))

--- a/leaf_common/session/grpc_client_retry.py
+++ b/leaf_common/session/grpc_client_retry.py
@@ -270,9 +270,9 @@ class GrpcClientRetry():
                 # See if the error is an RpcError with status codes
                 # that are registered as limited-retry.
                 if self.debug:
-                    self.logger.error(exception)
-                    error = traceback.format_exc()
                     sensitive_logger = SensitiveLogger(self.logger)
+                    sensitive_logger.error(exception)
+                    error = traceback.format_exc()
                     sensitive_logger.error(error)
 
                 log_exception = True


### PR DESCRIPTION
Use SenstiveLogger to funnel sensitive logs behind an env var.
This will help clear the CheckMarx scan.