### PR TITLE
fix: add optional basedir parameter to HoconSerializationFormat.to_object()

### DIFF
--- a/leaf_common/serialization/format/hocon_serialization_format.py
+++ b/leaf_common/serialization/format/hocon_serialization_format.py
@@ -34,7 +34,7 @@ class HoconSerializationFormat(JsonSerializationFormat):
     With this class, hocon serialization (from_object) is just JSON.
     """
 
-    def to_object(self, fileobj):
+    def to_object(self, fileobj, basedir=None):
         """
         :param fileobj: The file-like object to deserialize.
                 It is expected that the file-like object be open and be
@@ -43,6 +43,11 @@ class HoconSerializationFormat(JsonSerializationFormat):
 
                 After calling this method, the seek pointer will be at the end
                 of the data. Closing of the fileobj is left to the caller.
+        :param basedir: Optional base directory for resolving include directives.
+                When provided, HOCON include paths are resolved relative to this
+                directory rather than the process working directory. Pass the
+                directory of the file being parsed so that sibling includes work
+                correctly regardless of where the server is started from.
         :return: the deserialized object
         """
 
@@ -52,7 +57,7 @@ class HoconSerializationFormat(JsonSerializationFormat):
             hocon_string, _ = BytesDecoder.decode_bytes(hocon_bytes)
 
             # Load the HOCON into a dictionary
-            pruned_dict = ConfigFactory.parse_string(hocon_string)
+            pruned_dict = ConfigFactory.parse_string(hocon_string, basedir=basedir)
 
             # Hocon tends to produce regular dictionaries that have
             # ConfigTree structures for nested dictionaries.


### PR DESCRIPTION
## Summary

- **`leaf_common/serialization/format/hocon_serialization_format.py`**: Add an optional `basedir` parameter to `to_object()`, forwarded to `ConfigFactory.parse_string(basedir=basedir)`. Without this, `parse_string()` always resolves HOCON `include` paths relative to the process CWD, making include resolution fragile for callers that parse files located outside the working directory.

The parameter defaults to `None`, preserving existing behaviour for all current callers.

This is a prerequisite for the companion fix in `neuro-san` (`RawManifestRestorer` passes the manifest file's directory as `basedir` so sub-manifest includes work regardless of where the server is started from).

## Test plan

- [ ] Existing HOCON parsing with no `basedir` continues to resolve includes from CWD (no regression)
- [ ] Passing `basedir=<directory>` causes includes to resolve relative to that directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)