### PR TITLE
Have surface_import_errors flag on ResolverUtil.create_instance() that propagates install_if_missing

### DIFF
--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -75,7 +75,8 @@ class Resolver():
         if verbose:
             logger.info("Attempting to resolve module %s", use_module_name)
 
-        found_module: Any = self._find_module(use_module_name, messages, install_if_missing)
+        found_module: Any = self._find_module(use_module_name, messages, install_if_missing,
+                                              raise_if_not_found=raise_if_not_found)
 
         if found_module is None:
             message: str = f"Could not find code for {use_module_name}"
@@ -101,7 +102,7 @@ class Resolver():
         return my_class
 
     def _find_module(self, use_module_name: str, messages: List[str],
-                     install_if_missing: str = None) -> Any:
+                     install_if_missing: str = None, raise_if_not_found: bool = False) -> Any:
         """
         Searches for a module by name, trying each configured package in turn.
         Also tries the module name as a top-level module if packages are configured.
@@ -109,36 +110,38 @@ class Resolver():
         :param use_module_name: The module name to search for
         :param messages: a list of messages where logs of failed attempts can go
         :param install_if_missing: Optional name of a package to install if the module is missing.
+        :param raise_if_not_found: When True an error will be raised that the module could not be found
         :return: The python module if found. None if not found.
         """
 
         if self.packages is None:
-            return self.try_to_import_module(use_module_name, messages, install_if_missing)
+            return self.try_to_import_module(use_module_name, messages, install_if_missing, raise_if_not_found)
 
         for package in self.packages:
             fully_qualified_module: str = f"{package}.{use_module_name}"
             found_module: Any = self.try_to_import_module(fully_qualified_module,
-                                                          messages, install_if_missing)
+                                                          messages, install_if_missing, raise_if_not_found)
 
             if found_module is not None:
                 return found_module
 
             # check main package
-            check_main_package: Any = self.try_to_import_module(package,
-                                                                messages, install_if_missing)
+            check_main_package: Any = self.try_to_import_module(package, messages, install_if_missing,
+                                                                raise_if_not_found)
             if check_main_package is not None:
                 return check_main_package
 
         return None
 
     def try_to_import_module(self, module: str, messages: List[str],
-                             install_if_missing: str = None) -> Any:
+                             install_if_missing: str = None, raise_if_not_found: bool = False) -> Any:
         """
         Makes a single attempt to load a module
 
         :param module: The name of the module to load
         :param messages: a list of messages where logs of failed attempts can go
         :param install_if_missing: Optional name of a package to install if the module is missing.
+        :param raise_if_not_found: When True an error will be raised that the module could not be found
         :return: The python module if found. None if not found.
         """
 
@@ -151,6 +154,8 @@ class Resolver():
         except SyntaxError as exception:
             message = \
                 f"Module {module}: Couldn't load due to SyntaxError: {str(exception)}"
+            if raise_if_not_found:
+                raise ValueError(message) from exception
         except ImportError as exception:
             message = \
                 f"Module {module}: Couldn't load due to ImportError: {str(exception)}"
@@ -161,9 +166,13 @@ class Resolver():
                 message += "another directory"
             else:
                 message += f"Try pip installing the package {install_if_missing} to get past this error."
+            if raise_if_not_found:
+                raise ValueError(message) from exception
 
         except Exception as exception:      # pylint: disable=broad-except
             message = f"Module {module}: Couldn't load due to Exception: {str(exception)}"
+            if raise_if_not_found:
+                raise ValueError(message) from exception
 
         if message is not None:
             messages.append(message)

--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -48,7 +48,8 @@ class Resolver():
                                 module_name: str = None,
                                 raise_if_not_found: bool = True,
                                 verbose: bool = False,
-                                install_if_missing: str = None) -> Union[Type[Any], ModuleType]:
+                                install_if_missing: str = None,
+                                surface_import_errors: bool = False) -> Union[Type[Any], ModuleType]:
         """
         :param class_name: The name of the class we are looking for.
                         Can be None, in which case the module is returned
@@ -59,6 +60,8 @@ class Resolver():
                         the class could not be resolved.
         :param verbose: Controls how chatty the process is. Default False.
         :param install_if_missing: Optional name of a package to install if the module is missing.
+        :param surface_import_errors: When True, any import errors will be immediately raised.
+                    By default this is false so failures in lazy loading can slip by with no noise.
         :return: a reference to the Python class, if the class could be resolved,
                  or the module if class_name is None.
                  None otherwise.
@@ -76,7 +79,7 @@ class Resolver():
             logger.info("Attempting to resolve module %s", use_module_name)
 
         found_module: Any = self._find_module(use_module_name, messages, install_if_missing,
-                                              raise_if_not_found=raise_if_not_found)
+                                              surface_import_errors=surface_import_errors)
 
         if found_module is None:
             message: str = f"Could not find code for {use_module_name}"
@@ -102,7 +105,7 @@ class Resolver():
         return my_class
 
     def _find_module(self, use_module_name: str, messages: List[str],
-                     install_if_missing: str = None, raise_if_not_found: bool = False) -> Any:
+                     install_if_missing: str = None, surface_import_errors: bool = False) -> Any:
         """
         Searches for a module by name, trying each configured package in turn.
         Also tries the module name as a top-level module if packages are configured.
@@ -110,38 +113,38 @@ class Resolver():
         :param use_module_name: The module name to search for
         :param messages: a list of messages where logs of failed attempts can go
         :param install_if_missing: Optional name of a package to install if the module is missing.
-        :param raise_if_not_found: When True an error will be raised that the module could not be found
+        :param surface_import_errors: When True an exceptions will be raised immediately
         :return: The python module if found. None if not found.
         """
 
         if self.packages is None:
-            return self.try_to_import_module(use_module_name, messages, install_if_missing, raise_if_not_found)
+            return self.try_to_import_module(use_module_name, messages, install_if_missing, surface_import_errors)
 
         for package in self.packages:
             fully_qualified_module: str = f"{package}.{use_module_name}"
             found_module: Any = self.try_to_import_module(fully_qualified_module,
-                                                          messages, install_if_missing, raise_if_not_found)
+                                                          messages, install_if_missing, surface_import_errors)
 
             if found_module is not None:
                 return found_module
 
             # check main package
             check_main_package: Any = self.try_to_import_module(package, messages, install_if_missing,
-                                                                raise_if_not_found)
+                                                                surface_import_errors)
             if check_main_package is not None:
                 return check_main_package
 
         return None
 
     def try_to_import_module(self, module: str, messages: List[str],
-                             install_if_missing: str = None, raise_if_not_found: bool = False) -> Any:
+                             install_if_missing: str = None, surface_import_errors: bool = False) -> Any:
         """
         Makes a single attempt to load a module
 
         :param module: The name of the module to load
         :param messages: a list of messages where logs of failed attempts can go
         :param install_if_missing: Optional name of a package to install if the module is missing.
-        :param raise_if_not_found: When True an error will be raised that the module could not be found
+        :param surface_import_errors: When True an error will be raised that the module could not be found
         :return: The python module if found. None if not found.
         """
 
@@ -154,7 +157,7 @@ class Resolver():
         except SyntaxError as exception:
             message = \
                 f"Module {module}: Couldn't load due to SyntaxError: {str(exception)}"
-            if raise_if_not_found:
+            if surface_import_errors:
                 raise ValueError(message) from exception
         except ImportError as exception:
             message = \
@@ -166,12 +169,12 @@ class Resolver():
                 message += "another directory"
             else:
                 message += f"Try pip installing the package {install_if_missing} to get past this error."
-            if raise_if_not_found:
+            if surface_import_errors:
                 raise ValueError(message) from exception
 
         except Exception as exception:      # pylint: disable=broad-except
             message = f"Module {module}: Couldn't load due to Exception: {str(exception)}"
-            if raise_if_not_found:
+            if surface_import_errors:
                 raise ValueError(message) from exception
 
         if message is not None:

--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -118,19 +118,23 @@ class Resolver():
         """
 
         if self.packages is None:
-            return self.try_to_import_module(use_module_name, messages, install_if_missing, surface_import_errors)
+            return self.try_to_import_module(use_module_name, messages,
+                                             install_if_missing=install_if_missing,
+                                             surface_import_errors=surface_import_errors)
 
         for package in self.packages:
             fully_qualified_module: str = f"{package}.{use_module_name}"
-            found_module: Any = self.try_to_import_module(fully_qualified_module,
-                                                          messages, install_if_missing, surface_import_errors)
+            found_module: Any = self.try_to_import_module(fully_qualified_module, messages,
+                                                          install_if_missing=install_if_missing,
+                                                          surface_import_errors=surface_import_errors)
 
             if found_module is not None:
                 return found_module
 
             # check main package
-            check_main_package: Any = self.try_to_import_module(package, messages, install_if_missing,
-                                                                surface_import_errors)
+            check_main_package: Any = self.try_to_import_module(package, messages,
+                                                                install_if_missing=install_if_missing,
+                                                                surface_import_errors=surface_import_errors)
             if check_main_package is not None:
                 return check_main_package
 

--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -113,7 +113,7 @@ class Resolver():
         :param use_module_name: The module name to search for
         :param messages: a list of messages where logs of failed attempts can go
         :param install_if_missing: Optional name of a package to install if the module is missing.
-        :param surface_import_errors: When True an exceptions will be raised immediately
+        :param surface_import_errors: When True, an exception will be raised immediately.
         :return: The python module if found. None if not found.
         """
 

--- a/leaf_common/config/resolver.py
+++ b/leaf_common/config/resolver.py
@@ -148,7 +148,7 @@ class Resolver():
         :param module: The name of the module to load
         :param messages: a list of messages where logs of failed attempts can go
         :param install_if_missing: Optional name of a package to install if the module is missing.
-        :param surface_import_errors: When True an error will be raised that the module could not be found
+        :param surface_import_errors: When True an error will be raised that the module could not be loaded
         :return: The python module if found. None if not found.
         """
 

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -33,7 +33,7 @@ class ResolverUtil:
 
     @staticmethod
     def create_instance(class_name: str, class_name_source: str, type_of_class: Type,
-                        surface_import_errors: bool = False) -> Any:
+                        surface_import_errors: bool = True) -> Any:
         """
         Resolves the class_name to instantiate an instance of the class.
         Goes through some standard checking with standard exceptions thrown
@@ -44,6 +44,8 @@ class ResolverUtil:
                     class_name, so that exceptions can be more instructive.
         :param type_of_class: The type that the instance must be in order to pass muster.
         :param surface_import_errors: Raise an exception if the class cannot be instantiated
+                By defult this is True, because we assume that if we can't get the instance
+                it is because of an import error and the user will need to know why it didn't work.
         :return: An instance of the class referred to by class_name if everything is successful.
                 Can return None if class_name is a None or empty string.
         """

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -51,8 +51,8 @@ class ResolverUtil:
         """
 
         instance: Any = None
-        class_reference: Type[Any] = ResolverUtil.create_class(class_name, class_name_source,
-                                                               type_of_class, surface_import_errors)
+        class_reference: Type[Any] = ResolverUtil.create_class(class_name, class_name_source, type_of_class,
+                                                               surface_import_errors=surface_import_errors)
 
         if class_reference is None:
             return None

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -43,8 +43,8 @@ class ResolverUtil:
         :param class_name_source: A string description of where we are getting the value of
                     class_name, so that exceptions can be more instructive.
         :param type_of_class: The type that the instance must be in order to pass muster.
-        :param surface_import_errors: Raise an exception if the class cannot be instantiated
-                By defult this is True, because we assume that if we can't get the instance
+        :param surface_import_errors: Raise an exception if the class cannot be instantiated.
+                By default this is True, because we assume that if we can't get the instance
                 it is because of an import error and the user will need to know why it didn't work.
         :return: An instance of the class referred to by class_name if everything is successful.
                 Can return None if class_name is a None or empty string.

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -33,7 +33,7 @@ class ResolverUtil:
 
     @staticmethod
     def create_instance(class_name: str, class_name_source: str, type_of_class: Type,
-                        raise_on_failure: bool = True) -> Any:
+                        surface_import_errors: bool = False) -> Any:
         """
         Resolves the class_name to instantiate an instance of the class.
         Goes through some standard checking with standard exceptions thrown
@@ -43,14 +43,14 @@ class ResolverUtil:
         :param class_name_source: A string description of where we are getting the value of
                     class_name, so that exceptions can be more instructive.
         :param type_of_class: The type that the instance must be in order to pass muster.
-        :param raise_on_failure: Raise an exception if the class cannot be instantiated
+        :param surface_import_errors: Raise an exception if the class cannot be instantiated
         :return: An instance of the class referred to by class_name if everything is successful.
                 Can return None if class_name is a None or empty string.
         """
 
         instance: Any = None
         class_reference: Type[Any] = ResolverUtil.create_class(class_name, class_name_source,
-                                                               type_of_class, raise_on_failure)
+                                                               type_of_class, surface_import_errors)
 
         if class_reference is None:
             return None
@@ -66,7 +66,7 @@ class ResolverUtil:
 
     @staticmethod
     def create_class(class_name: str, class_name_source: str, type_of_class: Type,
-                     raise_on_failure: bool = True) -> Type:
+                     surface_import_errors: bool = False) -> Type:
         """
         Resolves a fully qualified class name string into an actual Python class object.
 
@@ -78,7 +78,7 @@ class ResolverUtil:
         :param class_name_source: A description of the source of the class_name string,
                 used for clearer error messages.
         :param type_of_class: Base type or interface the class must inherit from.
-        :param raise_on_failure: Raise an exception if the class cannot be resolved
+        :param surface_import_errors: Raise an exception if the class cannot be resolved
         :return: The resolved class object. Can return None if class_name is a None or empty string.
         """
 
@@ -109,7 +109,7 @@ class ResolverUtil:
         class_reference: Type[Any] = None
         try:
             class_reference = resolver.resolve_class_in_module(class_name, module_name=module_name,
-                                                               raise_if_not_found=raise_on_failure)
+                                                               surface_import_errors=surface_import_errors)
         except AttributeError as exception:
             raise ValueError(f"Class '{class_name}' from {class_name_source} "
                              "not found in PYTHONPATH") from exception

--- a/leaf_common/config/resolver_util.py
+++ b/leaf_common/config/resolver_util.py
@@ -32,7 +32,8 @@ class ResolverUtil:
     """
 
     @staticmethod
-    def create_instance(class_name: str, class_name_source: str, type_of_class: Type) -> Any:
+    def create_instance(class_name: str, class_name_source: str, type_of_class: Type,
+                        raise_on_failure: bool = True) -> Any:
         """
         Resolves the class_name to instantiate an instance of the class.
         Goes through some standard checking with standard exceptions thrown
@@ -42,12 +43,14 @@ class ResolverUtil:
         :param class_name_source: A string description of where we are getting the value of
                     class_name, so that exceptions can be more instructive.
         :param type_of_class: The type that the instance must be in order to pass muster.
+        :param raise_on_failure: Raise an exception if the class cannot be instantiated
         :return: An instance of the class referred to by class_name if everything is successful.
                 Can return None if class_name is a None or empty string.
         """
 
         instance: Any = None
-        class_reference: Type[Any] = ResolverUtil.create_class(class_name, class_name_source, type_of_class)
+        class_reference: Type[Any] = ResolverUtil.create_class(class_name, class_name_source,
+                                                               type_of_class, raise_on_failure)
 
         if class_reference is None:
             return None
@@ -62,7 +65,8 @@ class ResolverUtil:
         return instance
 
     @staticmethod
-    def create_class(class_name: str, class_name_source: str, type_of_class: Type) -> Type:
+    def create_class(class_name: str, class_name_source: str, type_of_class: Type,
+                     raise_on_failure: bool = True) -> Type:
         """
         Resolves a fully qualified class name string into an actual Python class object.
 
@@ -74,6 +78,7 @@ class ResolverUtil:
         :param class_name_source: A description of the source of the class_name string,
                 used for clearer error messages.
         :param type_of_class: Base type or interface the class must inherit from.
+        :param raise_on_failure: Raise an exception if the class cannot be resolved
         :return: The resolved class object. Can return None if class_name is a None or empty string.
         """
 
@@ -103,7 +108,8 @@ class ResolverUtil:
         # Resolve the class name
         class_reference: Type[Any] = None
         try:
-            class_reference = resolver.resolve_class_in_module(class_name, module_name=module_name)
+            class_reference = resolver.resolve_class_in_module(class_name, module_name=module_name,
+                                                               raise_if_not_found=raise_on_failure)
         except AttributeError as exception:
             raise ValueError(f"Class '{class_name}' from {class_name_source} "
                              "not found in PYTHONPATH") from exception

--- a/tests/config/resolver_util_test.py
+++ b/tests/config/resolver_util_test.py
@@ -69,7 +69,7 @@ class ResolverUtilTest(TestCase):
              patch("builtins.issubclass", return_value=True):
             result = ResolverUtil.create_class("my_package.MyClass", "test_source", object)
 
-        mock_resolve.assert_called_once_with("MyClass", module_name="my_package", raise_if_not_found=True)
+        mock_resolve.assert_called_once_with("MyClass", module_name="my_package", surface_import_errors=False)
         self.assertIs(result, mock_class)
 
     def test_create_class_three_part_name(self):
@@ -84,7 +84,7 @@ class ResolverUtilTest(TestCase):
                 "my_package.my_module.MyClass", "test_source", object
             )
 
-        mock_resolve.assert_called_once_with("MyClass", module_name="my_module", raise_if_not_found=True)
+        mock_resolve.assert_called_once_with("MyClass", module_name="my_module", surface_import_errors=False)
         self.assertIs(result, mock_class)
 
     def test_create_class_multi_part_package(self):
@@ -100,7 +100,7 @@ class ResolverUtilTest(TestCase):
                 "my_pkg.sub_pkg.my_module.MyClass", "test_source", object
             )
 
-        mock_resolve.assert_called_once_with("MyClass", module_name="my_module", raise_if_not_found=True)
+        mock_resolve.assert_called_once_with("MyClass", module_name="my_module", surface_import_errors=False)
         self.assertIs(result, mock_class)
 
     def test_create_class_attribute_error_raises_value_error(self):

--- a/tests/config/resolver_util_test.py
+++ b/tests/config/resolver_util_test.py
@@ -69,7 +69,7 @@ class ResolverUtilTest(TestCase):
              patch("builtins.issubclass", return_value=True):
             result = ResolverUtil.create_class("my_package.MyClass", "test_source", object)
 
-        mock_resolve.assert_called_once_with("MyClass", module_name="my_package")
+        mock_resolve.assert_called_once_with("MyClass", module_name="my_package", raise_if_not_found=True)
         self.assertIs(result, mock_class)
 
     def test_create_class_three_part_name(self):
@@ -84,7 +84,7 @@ class ResolverUtilTest(TestCase):
                 "my_package.my_module.MyClass", "test_source", object
             )
 
-        mock_resolve.assert_called_once_with("MyClass", module_name="my_module")
+        mock_resolve.assert_called_once_with("MyClass", module_name="my_module", raise_if_not_found=True)
         self.assertIs(result, mock_class)
 
     def test_create_class_multi_part_package(self):
@@ -100,7 +100,7 @@ class ResolverUtilTest(TestCase):
                 "my_pkg.sub_pkg.my_module.MyClass", "test_source", object
             )
 
-        mock_resolve.assert_called_once_with("MyClass", module_name="my_module")
+        mock_resolve.assert_called_once_with("MyClass", module_name="my_module", raise_if_not_found=True)
         self.assertIs(result, mock_class)
 
     def test_create_class_attribute_error_raises_value_error(self):


### PR DESCRIPTION
Have ResolverUtil.create_instance() surface import errors by default when they happen.
The expectation for this case is that the caller wants an actual instance, not just a class reference, 
so when that fails for whatever reason, it's worthwhile to surface the actual error, which can often point to an
install-this-package-if-missing message right off the bat.

Lots of plumbing to get this right. Plus some tests have to be updated.

The reason we are doing this now is because some dynamic loading "import this" errors were not surfacing at create_instance() time.