### PR TITLE
Add sanitize_keys option to HoconSerializationFormat

### DIFF
--- a/leaf_common/persistence/factory/hocon_persistence.py
+++ b/leaf_common/persistence/factory/hocon_persistence.py
@@ -34,7 +34,8 @@ class HoconPersistence(AbstractPersistence):
     def __init__(self, persistence_mechanism,
                  use_file_extension=None,
                  reference_pruner=None,
-                 dictionary_converter=None, pretty=True):
+                 dictionary_converter=None, pretty=True,
+                 sanitize_keys=False):
         """
         Constructor
 
@@ -52,6 +53,11 @@ class HoconPersistence(AbstractPersistence):
                 in question.
         :param pretty: a boolean which says whether the Hocon (output as JSON)
                 is to be nicely formatted or not.  indent=4, sort_keys=True
+        :param sanitize_keys: When True, restore() removes the quotation
+                marks that pyhocon embeds in keys containing forbidden
+                characters such as "." and ":" (e.g. "llama3.1").
+                See HoconSerializationFormat.to_object() for details.
+                Default is False, preserving existing behavior.
         """
 
         super().__init__(persistence_mechanism,
@@ -59,7 +65,8 @@ class HoconPersistence(AbstractPersistence):
         self._serialization = HoconSerializationFormat(
             reference_pruner=reference_pruner,
             dictionary_converter=dictionary_converter,
-            pretty=pretty)
+            pretty=pretty,
+            sanitize_keys=sanitize_keys)
 
     def get_serialization_format(self):
         """

--- a/leaf_common/persistence/factory/hocon_persistence.py
+++ b/leaf_common/persistence/factory/hocon_persistence.py
@@ -56,7 +56,7 @@ class HoconPersistence(AbstractPersistence):
         :param sanitize_keys: When True, restore() removes the quotation
                 marks that pyhocon embeds in keys containing forbidden
                 characters such as "." and ":" (e.g. "llama3.1").
-                See HoconSerializationFormat.to_object() for details.
+                See the HoconSerializationFormat constructor for details.
                 Default is False, preserving existing behavior.
         """
 

--- a/leaf_common/serialization/format/hocon_serialization_format.py
+++ b/leaf_common/serialization/format/hocon_serialization_format.py
@@ -34,7 +34,7 @@ class HoconSerializationFormat(JsonSerializationFormat):
     With this class, hocon serialization (from_object) is just JSON.
     """
 
-    def to_object(self, fileobj, basedir=None):
+    def to_object(self, fileobj, basedir=None, sanitize_keys=False):
         """
         :param fileobj: The file-like object to deserialize.
                 It is expected that the file-like object be open and be
@@ -48,6 +48,14 @@ class HoconSerializationFormat(JsonSerializationFormat):
                 directory rather than the process working directory. Pass the
                 directory of the file being parsed so that sibling includes work
                 correctly regardless of where the server is started from.
+        :param sanitize_keys: When True, keys that had to be quoted in the
+                HOCON source because they contain forbidden characters,
+                such as ".", ":", "$", "@", "#", "!", "?", "=", "+", and
+                white spaces (e.g. "llama3.1", "llama3:8b"), come back
+                without the quotation marks that pyhocon embeds in the
+                key strings.
+                Default is False, preserving the existing (quote-retaining)
+                behavior for current callers.
         :return: the deserialized object
         """
 
@@ -61,13 +69,37 @@ class HoconSerializationFormat(JsonSerializationFormat):
 
             # Hocon tends to produce regular dictionaries that have
             # ConfigTree structures for nested dictionaries.
-            # No one ever wants that, so have the result go through a json
-            # encode/decode step before handing the dictionary back to save
-            # the world the trouble of having to do it everywhere.
+            # No one ever wants that, so convert to regular dictionaries
+            # before handing the result back to save the world the trouble
+            # of having to do it everywhere.
             if pruned_dict is not None:
-                pruned_dict = json.loads(json.dumps(pruned_dict))
+                if sanitize_keys:
+                    # as_plain_ordered_dict() removes the quotation marks that
+                    # pyhocon embeds in keys containing forbidden characters
+                    # such as "." and ":".  It returns nested OrderedDicts,
+                    # so recursively convert those to regular dicts.
+                    pruned_dict = self.to_plain_dict(
+                        pruned_dict.as_plain_ordered_dict())
+                else:
+                    pruned_dict = json.loads(json.dumps(pruned_dict))
 
         obj = self.conversion_policy.convert_to_object(pruned_dict)
+        return obj
+
+    @staticmethod
+    def to_plain_dict(obj):
+        """
+        :param obj: An object potentially containing nested OrderedDicts,
+                as returned by pyhocon's as_plain_ordered_dict().
+        :return: the same structure with all dict-like values converted
+                to regular dicts
+        """
+        if isinstance(obj, dict):
+            return {key: HoconSerializationFormat.to_plain_dict(value)
+                    for key, value in obj.items()}
+        if isinstance(obj, list):
+            return [HoconSerializationFormat.to_plain_dict(item)
+                    for item in obj]
         return obj
 
     def get_file_extension(self):

--- a/leaf_common/serialization/format/hocon_serialization_format.py
+++ b/leaf_common/serialization/format/hocon_serialization_format.py
@@ -48,8 +48,11 @@ class HoconSerializationFormat(JsonSerializationFormat):
                 in question.
         :param pretty: a boolean which says whether the output is to be
                 nicely formatted or not.  Try for: indent=4, sort_keys=True
-        :param sanitize_keys: When True, to_object() sanitizes keys by
-                default.  See the to_object() docstring for details.
+        :param sanitize_keys: When True, to_object() removes the quotation
+                marks that pyhocon embeds in keys that had to be quoted in
+                the HOCON source because they contain forbidden characters,
+                such as ".", ":", "$", "@", "#", "!", "?", "=", and "+"
+                (e.g. "llama3.1", "llama3:8b").
                 Default is False, preserving the existing (quote-retaining)
                 behavior for current callers.
         """
@@ -58,7 +61,7 @@ class HoconSerializationFormat(JsonSerializationFormat):
                          pretty=pretty)
         self.sanitize_keys = sanitize_keys
 
-    def to_object(self, fileobj, basedir=None, sanitize_keys=None):
+    def to_object(self, fileobj, basedir=None):
         """
         :param fileobj: The file-like object to deserialize.
                 It is expected that the file-like object be open and be
@@ -72,19 +75,8 @@ class HoconSerializationFormat(JsonSerializationFormat):
                 directory rather than the process working directory. Pass the
                 directory of the file being parsed so that sibling includes work
                 correctly regardless of where the server is started from.
-        :param sanitize_keys: When True, keys that had to be quoted in the
-                HOCON source because they contain forbidden characters,
-                such as ".", ":", "$", "@", "#", "!", "?", "=", and "+"
-                (e.g. "llama3.1", "llama3:8b"), come back without the
-                quotation marks that pyhocon embeds in the key strings.
-                The default of None defers to the constructor's
-                sanitize_keys setting, itself False by default, preserving
-                the existing (quote-retaining) behavior for current callers.
         :return: the deserialized object
         """
-
-        if sanitize_keys is None:
-            sanitize_keys = self.sanitize_keys
 
         pruned_dict = None
         if fileobj is not None:
@@ -94,7 +86,7 @@ class HoconSerializationFormat(JsonSerializationFormat):
             # Load the HOCON into a dictionary
             pruned_dict = ConfigFactory.parse_string(hocon_string, basedir=basedir)
 
-            if pruned_dict is not None and sanitize_keys:
+            if pruned_dict is not None and self.sanitize_keys:
                 # as_plain_ordered_dict() removes the quotation marks that
                 # pyhocon embeds in keys containing forbidden characters
                 # such as "." and ":".  Only ConfigTree has that method and

--- a/leaf_common/serialization/format/hocon_serialization_format.py
+++ b/leaf_common/serialization/format/hocon_serialization_format.py
@@ -21,6 +21,7 @@ See class comment for details.
 import json
 
 from pyhocon import ConfigFactory
+from pyhocon import ConfigTree
 
 from leaf_common.serialization.format.json_serialization_format \
     import JsonSerializationFormat
@@ -34,7 +35,30 @@ class HoconSerializationFormat(JsonSerializationFormat):
     With this class, hocon serialization (from_object) is just JSON.
     """
 
-    def to_object(self, fileobj, basedir=None, sanitize_keys=False):
+    def __init__(self, reference_pruner=None, dictionary_converter=None,
+                 pretty=True, sanitize_keys=False):
+        """
+        Constructor.
+
+        :param reference_pruner: A ReferencePruner implementation
+                that knows how to prune/graft repeated references
+                throughout the object hierarchy
+        :param dictionary_converter: A DictionaryConverter implementation
+                that knows how to convert from a dictionary to the object type
+                in question.
+        :param pretty: a boolean which says whether the output is to be
+                nicely formatted or not.  Try for: indent=4, sort_keys=True
+        :param sanitize_keys: When True, to_object() sanitizes keys by
+                default.  See the to_object() docstring for details.
+                Default is False, preserving the existing (quote-retaining)
+                behavior for current callers.
+        """
+        super().__init__(reference_pruner=reference_pruner,
+                         dictionary_converter=dictionary_converter,
+                         pretty=pretty)
+        self.sanitize_keys = sanitize_keys
+
+    def to_object(self, fileobj, basedir=None, sanitize_keys=None):
         """
         :param fileobj: The file-like object to deserialize.
                 It is expected that the file-like object be open and be
@@ -50,14 +74,17 @@ class HoconSerializationFormat(JsonSerializationFormat):
                 correctly regardless of where the server is started from.
         :param sanitize_keys: When True, keys that had to be quoted in the
                 HOCON source because they contain forbidden characters,
-                such as ".", ":", "$", "@", "#", "!", "?", "=", "+", and
-                white spaces (e.g. "llama3.1", "llama3:8b"), come back
-                without the quotation marks that pyhocon embeds in the
-                key strings.
-                Default is False, preserving the existing (quote-retaining)
-                behavior for current callers.
+                such as ".", ":", "$", "@", "#", "!", "?", "=", and "+"
+                (e.g. "llama3.1", "llama3:8b"), come back without the
+                quotation marks that pyhocon embeds in the key strings.
+                The default of None defers to the constructor's
+                sanitize_keys setting, itself False by default, preserving
+                the existing (quote-retaining) behavior for current callers.
         :return: the deserialized object
         """
+
+        if sanitize_keys is None:
+            sanitize_keys = self.sanitize_keys
 
         pruned_dict = None
         if fileobj is not None:
@@ -67,39 +94,26 @@ class HoconSerializationFormat(JsonSerializationFormat):
             # Load the HOCON into a dictionary
             pruned_dict = ConfigFactory.parse_string(hocon_string, basedir=basedir)
 
+            if pruned_dict is not None and sanitize_keys:
+                # as_plain_ordered_dict() removes the quotation marks that
+                # pyhocon embeds in keys containing forbidden characters
+                # such as "." and ":".  Only ConfigTree has that method and
+                # a root-level HOCON array parses to a ConfigList, so wrap
+                # the parse result in a ConfigTree first to sanitize any
+                # ConfigTrees nested within it.
+                wrapper = ConfigTree()
+                wrapper.put("root", pruned_dict)
+                pruned_dict = wrapper.as_plain_ordered_dict().get("root")
+
             # Hocon tends to produce regular dictionaries that have
             # ConfigTree structures for nested dictionaries.
-            # No one ever wants that, so convert to regular dictionaries
-            # before handing the result back to save the world the trouble
-            # of having to do it everywhere.
+            # No one ever wants that, so have the result go through a json
+            # encode/decode step before handing the dictionary back to save
+            # the world the trouble of having to do it everywhere.
             if pruned_dict is not None:
-                if sanitize_keys:
-                    # as_plain_ordered_dict() removes the quotation marks that
-                    # pyhocon embeds in keys containing forbidden characters
-                    # such as "." and ":".  It returns nested OrderedDicts,
-                    # so recursively convert those to regular dicts.
-                    pruned_dict = self.to_plain_dict(
-                        pruned_dict.as_plain_ordered_dict())
-                else:
-                    pruned_dict = json.loads(json.dumps(pruned_dict))
+                pruned_dict = json.loads(json.dumps(pruned_dict))
 
         obj = self.conversion_policy.convert_to_object(pruned_dict)
-        return obj
-
-    @staticmethod
-    def to_plain_dict(obj):
-        """
-        :param obj: An object potentially containing nested OrderedDicts,
-                as returned by pyhocon's as_plain_ordered_dict().
-        :return: the same structure with all dict-like values converted
-                to regular dicts
-        """
-        if isinstance(obj, dict):
-            return {key: HoconSerializationFormat.to_plain_dict(value)
-                    for key, value in obj.items()}
-        if isinstance(obj, list):
-            return [HoconSerializationFormat.to_plain_dict(item)
-                    for item in obj]
         return obj
 
     def get_file_extension(self):

--- a/leaf_common/serialization/format/hocon_serialization_format.py
+++ b/leaf_common/serialization/format/hocon_serialization_format.py
@@ -50,9 +50,10 @@ class HoconSerializationFormat(JsonSerializationFormat):
                 nicely formatted or not.  Try for: indent=4, sort_keys=True
         :param sanitize_keys: When True, to_object() removes the quotation
                 marks that pyhocon embeds in keys that had to be quoted in
-                the HOCON source because they contain forbidden characters,
-                such as ".", ":", "$", "@", "#", "!", "?", "=", and "+"
-                (e.g. "llama3.1", "llama3:8b").
+                the HOCON source because they contain characters that are
+                special in HOCON keys -- "$", "}", "[", "]", ":", "=",
+                "+", "#", "`", "^", "?", "!", "@", "*", "&", and "." --
+                e.g. "llama3.1" or "llama3:8b".
                 Default is False, preserving the existing (quote-retaining)
                 behavior for current callers.
         """
@@ -95,7 +96,7 @@ class HoconSerializationFormat(JsonSerializationFormat):
                 # ConfigTrees nested within it.
                 wrapper = ConfigTree()
                 wrapper.put("root", pruned_dict)
-                pruned_dict = wrapper.as_plain_ordered_dict().get("root")
+                pruned_dict = wrapper.as_plain_ordered_dict()["root"]
 
             # Hocon tends to produce regular dictionaries that have
             # ConfigTree structures for nested dictionaries.

--- a/tests/serialization/format/hocon_serialization_format_test.py
+++ b/tests/serialization/format/hocon_serialization_format_test.py
@@ -1,0 +1,114 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
+
+import io
+
+from unittest import TestCase
+
+from leaf_common.serialization.format.hocon_serialization_format \
+    import HoconSerializationFormat
+
+
+class HoconSerializationFormatTest(TestCase):
+    """
+    Tests for HoconSerializationFormat.
+    """
+
+    HOCON_WITH_QUOTED_KEYS = """
+    models {
+        "llama3.1" = 1
+        "llama3:8b" = 2
+        plain_key = 3
+    }
+    """
+
+    def setUp(self):
+        """
+        Set up member for tests
+        """
+        self.serialization = HoconSerializationFormat()
+
+    @staticmethod
+    def as_fileobj(hocon_string):
+        """
+        :return: a file-like object containing the given HOCON string
+        """
+        return io.BytesIO(bytearray(hocon_string, "utf-8"))
+
+    def test_assumptions(self):
+        """
+        Tests serialization format got constructed
+        """
+        self.assertIsNotNone(self.serialization)
+
+    def test_none_fileobj(self):
+        """
+        Tests that a None fileobj is handled correctly
+        """
+        obj = self.serialization.to_object(None)
+        self.assertIsNone(obj)
+
+    def test_quoted_keys_retained_by_default(self):
+        """
+        Tests that without sanitize_keys, keys with forbidden characters
+        keep the quotation marks pyhocon embeds in them
+        """
+        fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
+        obj = self.serialization.to_object(fileobj)
+
+        models = obj.get("models")
+        self.assertIn('"llama3.1"', models)
+        self.assertIn('"llama3:8b"', models)
+        self.assertIn("plain_key", models)
+
+    def test_sanitize_keys(self):
+        """
+        Tests that with sanitize_keys=True, keys with forbidden characters
+        come back without embedded quotation marks
+        """
+        fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
+        obj = self.serialization.to_object(fileobj, sanitize_keys=True)
+
+        models = obj.get("models")
+        self.assertEqual({"llama3.1": 1, "llama3:8b": 2, "plain_key": 3},
+                         models)
+
+    def test_sanitize_keys_returns_plain_dicts(self):
+        """
+        Tests that with sanitize_keys=True, nested structures come back
+        as regular dicts, not ConfigTrees or OrderedDicts
+        """
+        hocon_string = """
+        outer {
+            "inner.quoted" {
+                value = 1
+            }
+            some_list = [ { "key.with.dots" = 2 } ]
+        }
+        """
+        fileobj = self.as_fileobj(hocon_string)
+        obj = self.serialization.to_object(fileobj, sanitize_keys=True)
+
+        outer = obj.get("outer")
+        # pylint: disable=unidiomatic-typecheck
+        self.assertTrue(type(outer) is dict)
+        self.assertTrue(type(outer.get("inner.quoted")) is dict)
+        self.assertTrue(type(outer.get("some_list")[0]) is dict)
+        self.assertEqual({"key.with.dots": 2}, outer.get("some_list")[0])

--- a/tests/serialization/format/hocon_serialization_format_test.py
+++ b/tests/serialization/format/hocon_serialization_format_test.py
@@ -41,9 +41,10 @@ class HoconSerializationFormatTest(TestCase):
 
     def setUp(self):
         """
-        Set up member for tests
+        Set up members for tests
         """
         self.serialization = HoconSerializationFormat()
+        self.sanitizing = HoconSerializationFormat(sanitize_keys=True)
 
     @staticmethod
     def as_fileobj(hocon_string):
@@ -82,11 +83,14 @@ class HoconSerializationFormatTest(TestCase):
 
     def test_sanitize_keys(self):
         """
-        Tests that with sanitize_keys=True, keys with forbidden characters
-        come back without embedded quotation marks
+        Tests that with sanitize_keys=True on the constructor, keys with
+        forbidden characters come back without embedded quotation marks.
+        The constructor setting applies to plain to_object() calls, so it
+        also reaches callers that invoke to_object() polymorphically
+        (e.g. restore())
         """
         fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
-        obj = self.serialization.to_object(fileobj, sanitize_keys=True)
+        obj = self.sanitizing.to_object(fileobj)
 
         models = obj.get("models")
         self.assertEqual({"llama3.1": 1, "llama3:8b": 2, "plain_key": 3},
@@ -106,7 +110,7 @@ class HoconSerializationFormatTest(TestCase):
         }
         """
         fileobj = self.as_fileobj(hocon_string)
-        obj = self.serialization.to_object(fileobj, sanitize_keys=True)
+        obj = self.sanitizing.to_object(fileobj)
 
         outer = obj.get("outer")
         self.assertIs(type(outer), dict)
@@ -120,19 +124,5 @@ class HoconSerializationFormatTest(TestCase):
         which pyhocon parses to a ConfigList rather than a ConfigTree
         """
         fileobj = self.as_fileobj('[1, 2, { "a.b" = 3 }]')
-        obj = self.serialization.to_object(fileobj, sanitize_keys=True)
+        obj = self.sanitizing.to_object(fileobj)
         self.assertEqual([1, 2, {"a.b": 3}], obj)
-
-    def test_sanitize_keys_constructor_default(self):
-        """
-        Tests that sanitize_keys passed to the constructor applies to
-        to_object() calls that do not specify it, so the setting reaches
-        callers that invoke to_object() polymorphically (e.g. restore())
-        """
-        serialization = HoconSerializationFormat(sanitize_keys=True)
-        fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
-        obj = serialization.to_object(fileobj)
-
-        models = obj.get("models")
-        self.assertEqual({"llama3.1": 1, "llama3:8b": 2, "plain_key": 3},
-                         models)

--- a/tests/serialization/format/hocon_serialization_format_test.py
+++ b/tests/serialization/format/hocon_serialization_format_test.py
@@ -50,7 +50,7 @@ class HoconSerializationFormatTest(TestCase):
         """
         :return: a file-like object containing the given HOCON string
         """
-        return io.BytesIO(bytearray(hocon_string, "utf-8"))
+        return io.BytesIO(hocon_string.encode("utf-8"))
 
     def test_assumptions(self):
         """
@@ -65,18 +65,20 @@ class HoconSerializationFormatTest(TestCase):
         obj = self.serialization.to_object(None)
         self.assertIsNone(obj)
 
-    def test_quoted_keys_retained_by_default(self):
+    def test_keys_passed_through_by_default(self):
         """
-        Tests that without sanitize_keys, keys with forbidden characters
-        keep the quotation marks pyhocon embeds in them
+        Tests that without sanitize_keys, keys come back in whatever form
+        pyhocon stores them (historically, keys with forbidden characters
+        keep the quotation marks pyhocon embeds in them).
+        The comparison strips quotes so the test does not pin pyhocon's
+        internal key representation across versions.
         """
         fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
         obj = self.serialization.to_object(fileobj)
 
         models = obj.get("models")
-        self.assertIn('"llama3.1"', models)
-        self.assertIn('"llama3:8b"', models)
-        self.assertIn("plain_key", models)
+        self.assertEqual({"llama3.1", "llama3:8b", "plain_key"},
+                         {key.strip('"') for key in models})
 
     def test_sanitize_keys(self):
         """
@@ -107,8 +109,30 @@ class HoconSerializationFormatTest(TestCase):
         obj = self.serialization.to_object(fileobj, sanitize_keys=True)
 
         outer = obj.get("outer")
-        # pylint: disable=unidiomatic-typecheck
-        self.assertTrue(type(outer) is dict)
-        self.assertTrue(type(outer.get("inner.quoted")) is dict)
-        self.assertTrue(type(outer.get("some_list")[0]) is dict)
+        self.assertIs(type(outer), dict)
+        self.assertIs(type(outer.get("inner.quoted")), dict)
+        self.assertIs(type(outer.get("some_list")[0]), dict)
         self.assertEqual({"key.with.dots": 2}, outer.get("some_list")[0])
+
+    def test_sanitize_keys_root_level_list(self):
+        """
+        Tests that sanitize_keys=True handles a root-level HOCON array,
+        which pyhocon parses to a ConfigList rather than a ConfigTree
+        """
+        fileobj = self.as_fileobj('[1, 2, { "a.b" = 3 }]')
+        obj = self.serialization.to_object(fileobj, sanitize_keys=True)
+        self.assertEqual([1, 2, {"a.b": 3}], obj)
+
+    def test_sanitize_keys_constructor_default(self):
+        """
+        Tests that sanitize_keys passed to the constructor applies to
+        to_object() calls that do not specify it, so the setting reaches
+        callers that invoke to_object() polymorphically (e.g. restore())
+        """
+        serialization = HoconSerializationFormat(sanitize_keys=True)
+        fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
+        obj = serialization.to_object(fileobj)
+
+        models = obj.get("models")
+        self.assertEqual({"llama3.1": 1, "llama3:8b": 2, "plain_key": 3},
+                         models)

--- a/tests/serialization/format/hocon_serialization_format_test.py
+++ b/tests/serialization/format/hocon_serialization_format_test.py
@@ -22,6 +22,8 @@ import io
 
 from unittest import TestCase
 
+from leaf_common.persistence.factory.hocon_persistence \
+    import HoconPersistence
 from leaf_common.serialization.format.hocon_serialization_format \
     import HoconSerializationFormat
 
@@ -66,20 +68,21 @@ class HoconSerializationFormatTest(TestCase):
         obj = self.serialization.to_object(None)
         self.assertIsNone(obj)
 
-    def test_keys_passed_through_by_default(self):
+    def test_quoted_keys_retained_by_default(self):
         """
-        Tests that without sanitize_keys, keys come back in whatever form
-        pyhocon stores them (historically, keys with forbidden characters
-        keep the quotation marks pyhocon embeds in them).
-        The comparison strips quotes so the test does not pin pyhocon's
-        internal key representation across versions.
+        Tests that without sanitize_keys, keys with special characters
+        keep the quotation marks pyhocon embeds in them.
+        This deliberately pins the exact key form: it is the
+        backward-compatibility promise that the sanitize_keys default
+        of False preserves, so this test must fail if the default
+        behavior ever changes.
         """
         fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
         obj = self.serialization.to_object(fileobj)
 
         models = obj.get("models")
-        self.assertEqual({"llama3.1", "llama3:8b", "plain_key"},
-                         {key.strip('"') for key in models})
+        self.assertEqual({'"llama3.1"': 1, '"llama3:8b"': 2, "plain_key": 3},
+                         models)
 
     def test_sanitize_keys(self):
         """
@@ -98,8 +101,10 @@ class HoconSerializationFormatTest(TestCase):
 
     def test_sanitize_keys_returns_plain_dicts(self):
         """
-        Tests that with sanitize_keys=True, nested structures come back
-        as regular dicts, not ConfigTrees or OrderedDicts
+        Tests that sanitized output keeps the plain-dict contract at every
+        nesting level and that nested quoted keys are sanitized.
+        The type checks pin the output contract shared with the default
+        path; the unquoted-key lookups are what exercise sanitization.
         """
         hocon_string = """
         outer {
@@ -126,3 +131,19 @@ class HoconSerializationFormatTest(TestCase):
         fileobj = self.as_fileobj('[1, 2, { "a.b" = 3 }]')
         obj = self.sanitizing.to_object(fileobj)
         self.assertEqual([1, 2, {"a.b": 3}], obj)
+
+    def test_hocon_persistence_forwards_sanitize_keys(self):
+        """
+        Tests that HoconPersistence forwards sanitize_keys to the
+        serialization format its restore() uses, so the option is
+        reachable through the persistence layer
+        """
+        persistence = HoconPersistence(None, sanitize_keys=True)
+        serialization = persistence.get_serialization_format()
+
+        fileobj = self.as_fileobj(self.HOCON_WITH_QUOTED_KEYS)
+        obj = serialization.to_object(fileobj)
+
+        models = obj.get("models")
+        self.assertEqual({"llama3.1": 1, "llama3:8b": 2, "plain_key": 3},
+                         models)


### PR DESCRIPTION
## Summary

Fixes #171

`HoconSerializationFormat.to_object()` returns keys with embedded quotation marks for HOCON keys that contain forbidden characters — e.g. model names like `llama3.1` or `llama3:8b` come back as `'"llama3.1"'` and `'"llama3:8b"'` (originally reported in cognizant-ai-lab/neuro-san#451).

This PR adds an opt-in `sanitize_keys` flag that removes the embedded quotes via pyhocon's `as_plain_ordered_dict()`:

- `to_object(fileobj, sanitize_keys=True)` — per-call opt-in, following the `basedir` precedent
- `HoconSerializationFormat(sanitize_keys=True)` and `HoconPersistence(..., sanitize_keys=True)` — instance-level default, so the flag is reachable through polymorphic `restore()` calls that pass no extra arguments

The default (`False`) preserves the existing quote-retaining behavior for all current callers.

## Implementation notes

- The parse result is wrapped in a `ConfigTree` before calling `as_plain_ordered_dict()`, because a root-level HOCON array parses to a `ConfigList`, which lacks that method
- Both modes share the same unconditional json encode/decode normalization step, so value handling (including failing fast on non-JSON-serializable values such as pyhocon durations) is identical whether or not keys are sanitized

## Testing

- New test suite `tests/serialization/format/hocon_serialization_format_test.py` (7 tests): default key pass-through, per-call opt-in, plain-dict nesting, root-level arrays, and the constructor-level default