### PR TITLE
Move common logging setup stuff from leaf_server_common into leaf_common.logging

### DIFF
--- a/leaf_common/logging/logging_setup.py
+++ b/leaf_common/logging/logging_setup.py
@@ -17,14 +17,19 @@
 """
 See class comment for details.
 """
+from typing import Any
+from typing import Dict
 
 import inspect
 import logging
 import logging.config
 import os
+from threading import current_thread
 
 from leaf_common.config.config_handler import ConfigHandler
+from leaf_common.logging.service_log_record import ServiceLogRecord
 from leaf_common.logging.stream_to_logger import StreamToLogger
+from leaf_common.logging.structured_log_record import StructuredLogRecord
 
 
 # pylint: disable=too-many-instance-attributes
@@ -241,3 +246,86 @@ class LoggingSetup():
         partial_relative_path = os.path.join(relative_dir, relative_filepath)
         absolute_file_path = os.path.abspath(partial_relative_path)
         return absolute_file_path
+
+    @staticmethod
+    def setup_extra_logging_fields(metadata_dict: Dict[str, Any] = None,
+                                   extra_logging_fields: Dict[str, str] = None):
+        """
+        Sets up extra thread-specific fields to be logged with each
+        log message.
+
+        :param metadata_dict: Metadata dictionary. Default is None
+        :param extra_logging_fields: Additional fields dictionary. Default is None
+        """
+
+        # Assumes ServiceLogRecord.set_up_record_factory() has already been called once
+        # what is returned is really a copy.
+        extra = ServiceLogRecord.get_default_extra_logging_fields()
+        if extra is None:
+            extra = {}
+        if extra_logging_fields is not None:
+            extra.update(extra_logging_fields)
+
+        extra["thread_name"] = current_thread().name
+
+        # Get information from the GRPC client context that is to be
+        # put into the logs.
+        if metadata_dict is not None:
+
+            for key in extra:
+                if key in ("source", "thread_name"):
+                    # Pass these up. They should not be coming from
+                    # any metadata dictionary in the request
+                    continue
+
+                # Override the defaults with what was in the metadata_dict
+                # Do not incorporate any fields that were not already
+                # in the accumulated extra dictionary.
+                value = metadata_dict.get(key, None)
+                if value is not None:
+                    extra[key] = str(value)
+
+        # Create the ServiceLogRecord thread-local context.
+        # In doing so like this, we actually are setting up global variables.
+        service_log_record = ServiceLogRecord()
+        service_log_record.set_logging_fields_dict(extra)
+
+    @staticmethod
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def setup_logging(server_name_for_logs: str,
+                      default_log_dir: str = ".",
+                      log_config_env: str = None,
+                      log_level_env: str = None,
+                      extra_logging_fields_defaults: Dict[str, str] = None,
+                      logging_config: Dict[str, Any] = None):
+        """
+        Setup logging to be used by ServerLifeTime
+        """
+        default_extra_logging_fields = {
+            "source": server_name_for_logs,
+            "thread_name": "Unknown",
+            "request_id": "None",
+            "user_id": "None",
+            "group_id": "None",
+            "run_id": "None",
+            "experiment_id": "None"
+        }
+
+        extras = extra_logging_fields_defaults
+        if extras is None:
+            extras = default_extra_logging_fields
+
+        logging_setup = LoggingSetup(default_log_config_dir=default_log_dir,
+                                     default_log_config_file="logging.json",
+                                     default_log_level="DEBUG",
+                                     log_config_env=log_config_env,
+                                     log_level_env=log_level_env,
+                                     logging_config=logging_config)
+        logging_setup.setup()
+
+        # Enable translation of log message args to MessageType
+        StructuredLogRecord.set_up_record_factory()
+
+        # Enable thread-local information to go into log messages
+        ServiceLogRecord.set_up_record_factory(extras)
+        logging_setup.setup_extra_logging_fields(extra_logging_fields=extras)

--- a/leaf_common/logging/message_types.py
+++ b/leaf_common/logging/message_types.py
@@ -1,0 +1,57 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from enum import Enum
+from logging import INFO
+from logging import addLevelName
+
+
+# We need to use specific logging levels for our own message types to
+# have our LogRecord derivitives be compatible with stock python loggers.
+# To be sure the API and METRICS log levels show up when log-level INFO is on,
+# we make their log level intefer value a few clicks up from INFO.
+# Seeing API is more important than seeing METRICS
+# pylint: disable=invalid-name
+API = INFO + 7
+METRICS = INFO + 5
+
+# Give the new log levels names for standard reporting
+addLevelName(API, "API")
+addLevelName(METRICS, "METRICS")
+
+
+class MessageType(str, Enum):
+    """
+    Represents the various types of log messages an application may generate.
+    """
+
+    # For messages that do not fit into any of the other categories
+    # Used for DEBUG and INFO
+    OTHER = 'Other'
+
+    # Error messages intended for technical personnel, such as internal errors, stack traces
+    # Used for CRITICAL, ERROR, and exception()
+    ERROR = 'Error'
+
+    # Warning only
+    WARNING = 'Warning'
+
+    # Metrics messages, for example, API call counts
+    METRICS = 'Metrics'
+
+    # Tracking API calls
+    API = 'API'

--- a/leaf_common/logging/service_log_record.py
+++ b/leaf_common/logging/service_log_record.py
@@ -1,0 +1,149 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import copy
+import logging
+import threading
+
+
+# Set up some global variables to allow cascading of LogRecord factories
+_SERVICE_OLD_FACTORY = None
+_DEFAULT_EXTRA_LOGGING_FIELDS_DICT = {}
+
+_SERVICE_LOGGING_FIELDS_KEY = "service_logging_fields_dict"
+
+
+def _service_log_record_factory(*args, **kwargs):
+    """
+    Expected entry point for standard Python logging system to be
+    used with the ServiceLogRecord class below.
+    This needs to be a regular method, dissociated from any class.
+
+    :param args: The positional arguments to the invocation of the
+                 LogRecord constructor
+    :param kwargs: The keyword arguments to the invocation of the
+                 LogRecord constructor
+    :return: A LogRecord instance from the Python logging package
+            with added thread-specific fields added.
+    """
+
+    # Use the class variable to get a handle on the old LogRecord factory
+    log_record = _SERVICE_OLD_FACTORY(*args, **kwargs)
+
+    # Get the current threads attributes as a dictionary
+    current_thread = threading.current_thread()
+    thread_dict = current_thread.__dict__
+
+    # Find the logging fields dictionary from the current thread
+    logging_fields_dict = _DEFAULT_EXTRA_LOGGING_FIELDS_DICT
+    if _SERVICE_LOGGING_FIELDS_KEY in thread_dict:
+        logging_fields_dict = thread_dict[_SERVICE_LOGGING_FIELDS_KEY]
+
+    # Get the current LogRecord as a dictionary
+    log_record_dict = log_record.__dict__
+
+    # Update the record dict with the key/value pairs set up
+    # in the logging fields dict
+    log_record_dict.update(logging_fields_dict)
+
+    # Return the new LogRecord with the new logging fields set
+    return log_record
+
+
+class ServiceLogRecord():
+    """
+    Helper class which adds extra fields pertinent to service logging
+    messages via the standard Python LogRecord class.
+
+    Extra logging fields are stored in a dictionary on thread-local storage,
+    so the lifetime of a single one of these objects should be the length
+    of the context of the thread-specific information, which is typically
+    the time it takes to service a single service request.
+
+    The extra logging fields themselves do not have to be defined at this
+    level.  They can be anything the client code wants.
+    """
+
+    @classmethod
+    def set_up_record_factory(cls, default_extra_logging_fields=None):
+        """
+        Called early on in the lifetime of a service to redirect the standard
+        Python LogRecord creation to our _record_factory() call at the top
+        of the file.
+
+        This needs to be called once by a service before any constructor of
+        this class is called or message is logged.
+        """
+
+        # Need to access global variable. No other way.
+        # Hacktastic python logging infrastructure is riddled with global needs
+        # pylint: disable=global-statement
+        global _SERVICE_OLD_FACTORY
+        if _SERVICE_OLD_FACTORY is None:
+            _SERVICE_OLD_FACTORY = logging.getLogRecordFactory()
+
+        if default_extra_logging_fields is not None:
+            # pylint: disable=global-statement
+            global _DEFAULT_EXTRA_LOGGING_FIELDS_DICT
+            _DEFAULT_EXTRA_LOGGING_FIELDS_DICT = copy.copy(default_extra_logging_fields)
+
+        logging.setLogRecordFactory(_service_log_record_factory)
+
+    @classmethod
+    def get_default_extra_logging_fields(cls):
+        """
+        :return: The dictionary previously passed into set_up_record_factory()
+        """
+        # pylint: disable=global-statement,global-variable-not-assigned
+        global _DEFAULT_EXTRA_LOGGING_FIELDS_DICT       # noqa: F824
+        default_extra_logging_fields = copy.copy(_DEFAULT_EXTRA_LOGGING_FIELDS_DICT)
+        return default_extra_logging_fields
+
+    def __init__(self, logging_fields_dict=None):
+        """
+        Constructor.
+
+        :param logging_fields_dict: Dictionary with thread-specific information
+                for logging, whose keys will become attributes on a LogRecord.
+                By default this is None, implying that an empty dictionary
+                will be initially created as a placeholder for the thread's
+                additional log messaging fields.
+        """
+        # Get the current thread
+        current_thread = threading.current_thread()
+
+        # Get the dictionary for the current thread structure
+        thread_dict = current_thread.__dict__
+
+        use_dict = logging_fields_dict
+        if use_dict is None:
+            use_dict = {}
+
+        # Create our own dictionary as an instance variable
+        self.thread_local_dict = use_dict
+
+        # Save the new instance dict on the thread dictionary as an attribute
+        thread_dict[_SERVICE_LOGGING_FIELDS_KEY] = self.thread_local_dict
+
+    def set_logging_fields_dict(self, logging_fields_dict):
+        """
+        Called once when a service request is initiated.
+
+        :param logging_fields_dict:  The thread-specific dictionary containing
+            logging fields that will be added to each LogRecord produced.
+        """
+        self.thread_local_dict.update(logging_fields_dict)

--- a/leaf_common/logging/structured_log_record.py
+++ b/leaf_common/logging/structured_log_record.py
@@ -1,0 +1,109 @@
+
+# Copyright © 2019-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import logging
+from datetime import datetime
+
+from leaf_common.logging.message_types import MessageType
+from leaf_common.logging.message_types import API
+from leaf_common.logging.message_types import METRICS
+
+
+# Set up a global variable to allow cascading of LogRecord factories
+_STRUCTURED_OLD_FACTORY = None
+
+
+def _structured_log_record_factory(*args, **kwargs):
+    """
+    Expected entry point for standard Python logging system to be
+    used with the StructuredLogRecord class below.
+    This needs to be a regular method, dissociated from any class.
+
+    :param args: The positional arguments to the invocation of the
+                 LogRecord constructor
+    :param kwargs: The keyword arguments to the invocation of the
+                 LogRecord constructor
+    :return: A LogRecord instance from the Python logging package
+            with added thread-specific fields added.
+    """
+
+    # Use the class variable to get a handle on the old LogRecord factory
+    log_record = _STRUCTURED_OLD_FACTORY(*args, **kwargs)
+
+    # Determine the MessageType we wish to store with each LogRecord
+    if log_record.exc_info is not None:
+        message_type = MessageType.ERROR
+    elif log_record.levelno == logging.CRITICAL:
+        message_type = MessageType.ERROR
+    elif log_record.levelno == logging.ERROR:
+        message_type = MessageType.ERROR
+    elif log_record.levelno == logging.WARNING:
+        message_type = MessageType.WARNING
+    elif log_record.levelno == API:
+        message_type = MessageType.API
+    elif log_record.levelno == METRICS:
+        message_type = MessageType.METRICS
+    elif log_record.levelno == logging.INFO:
+        message_type = MessageType.OTHER
+    elif log_record.levelno == logging.DEBUG:
+        message_type = MessageType.OTHER
+    else:
+        message_type = MessageType.OTHER
+
+    # Add the message_type as a string field to the log_record
+    log_record.message_type = message_type.value
+
+    # Add a log_record field for the structured timestamp
+    log_timestamp_since_epoch = log_record.created
+    log_datetime = datetime.fromtimestamp(log_timestamp_since_epoch)
+    iso_timestamp = log_datetime.isoformat()
+    log_record.iso_timestamp = iso_timestamp
+
+    # Return the new LogRecord with the new logging fields set
+    return log_record
+
+
+# pylint: disable=too-few-public-methods
+class StructuredLogRecord():
+    """
+    Helper class which adds extra fields pertinent to service logging
+    messages via the standard Python LogRecord class.
+
+    Extra logging fields that contribute to structured logging are stored
+    on the python logging system's LogRecord class that is created for
+    each log message.  In particular, a 'message_type' field is created
+    from the log level of each message coming in and a new iso formatted
+    time field is added for each message as well.
+    """
+
+    @classmethod
+    def set_up_record_factory(cls):
+        """
+        Called early on in the lifetime of a service to redirect the standard
+        Python LogRecord creation to our _record_factory() call at the top
+        of the file.
+
+        This needs to be called once by a service before any constructor of
+        this class is called or message is logged.
+        """
+        # Need to access global variable. No other way.
+        # Hacktastic python logging infrastructure is riddled with global needs
+        # pylint: disable=global-statement
+        global _STRUCTURED_OLD_FACTORY
+        if _STRUCTURED_OLD_FACTORY is None:
+            _STRUCTURED_OLD_FACTORY = logging.getLogRecordFactory()
+        logging.setLogRecordFactory(_structured_log_record_factory)


### PR DESCRIPTION
Move message_types, structured_log_record, service_log_record and some methods into logging_setup.
This will help client-y bits of neuro-san not depend on leaf-server-common